### PR TITLE
feat: focus on search input at startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,9 @@ var AppVersion = "dev"
 // configFile holds the path to the SSH config file
 var configFile string
 
+// searchMode enables the focus on search mode at startup
+var searchMode bool
+
 // RootCmd is the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "sshm [host]",
@@ -97,7 +100,7 @@ func runInteractiveMode() {
 	}
 
 	// Run the interactive TUI
-	if err := ui.RunInteractiveMode(hosts, configFile, AppVersion); err != nil {
+	if err := ui.RunInteractiveMode(hosts, configFile, searchMode, AppVersion); err != nil {
 		log.Fatalf("Error running interactive mode: %v", err)
 	}
 }
@@ -219,6 +222,7 @@ func Execute() {
 func init() {
 	// Add the config file flag
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "SSH config file to use (default: ~/.ssh/config)")
+	RootCmd.PersistentFlags().BoolVarP(&searchMode, "search", "s", false, "Focus on search input at startup")
 
 	// Set custom version template with update check
 	RootCmd.SetVersionTemplate(getVersionWithUpdateCheck())

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -16,7 +16,7 @@ import (
 )
 
 // NewModel creates a new TUI model with the given SSH hosts
-func NewModel(hosts []config.SSHHost, configFile, currentVersion string) Model {
+func NewModel(hosts []config.SSHHost, configFile string, searchMode bool, currentVersion string) Model {
 	// Load application configuration
 	appConfig, err := config.LoadAppConfig()
 	if err != nil {
@@ -54,6 +54,7 @@ func NewModel(hosts []config.SSHHost, configFile, currentVersion string) Model {
 		height:         24,
 		ready:          false,
 		viewMode:       ViewList,
+		searchMode:     searchMode,
 	}
 
 	// Sort hosts according to the default sort mode
@@ -64,6 +65,9 @@ func NewModel(hosts []config.SSHHost, configFile, currentVersion string) Model {
 	ti.Placeholder = "Search hosts or tags..."
 	ti.CharLimit = 50
 	ti.Width = 25
+	if searchMode {
+		ti.Focus()
+	}
 
 	// Use dynamic column width calculation (will fallback to static if width not available)
 	nameWidth, hostnameWidth, tagsWidth, lastLoginWidth := m.calculateDynamicColumnWidths(sortedHosts)
@@ -147,8 +151,8 @@ func NewModel(hosts []config.SSHHost, configFile, currentVersion string) Model {
 }
 
 // RunInteractiveMode starts the interactive TUI interface
-func RunInteractiveMode(hosts []config.SSHHost, configFile, currentVersion string) error {
-	m := NewModel(hosts, configFile, currentVersion)
+func RunInteractiveMode(hosts []config.SSHHost, configFile string, searchMode bool, currentVersion string) error {
+	m := NewModel(hosts, configFile, searchMode, currentVersion)
 
 	// Start the application in alt screen mode for clean output
 	p := tea.NewProgram(m, tea.WithAltScreen())


### PR DESCRIPTION
Add an option (-s or --search) to focus on the search input at startup