### PR TITLE
Align add/edit form navigation behavior

### DIFF
--- a/internal/ui/add_form.go
+++ b/internal/ui/add_form.go
@@ -275,11 +275,29 @@ func (m *addFormModel) handleNavigation(key string) tea.Cmd {
 		currentPos++
 	}
 
-	// Wrap around within current tab
+	// Handle transitions between tabs
 	if currentPos >= len(currentTabInputs) {
-		currentPos = 0
+		// Move to next tab
+		if m.currentTab == tabGeneral {
+			// Move to advanced tab
+			m.currentTab = tabAdvanced
+			m.focused = m.getFirstInputForTab(tabAdvanced)
+			return m.updateFocus()
+		} else {
+			// Wrap around to first field of current tab
+			currentPos = 0
+		}
 	} else if currentPos < 0 {
-		currentPos = len(currentTabInputs) - 1
+		// Move to previous tab
+		if m.currentTab == tabAdvanced {
+			// Move to general tab
+			m.currentTab = tabGeneral
+			currentTabInputs = m.getInputsForCurrentTab()
+			currentPos = len(currentTabInputs) - 1
+		} else {
+			// Wrap around to last field of current tab
+			currentPos = len(currentTabInputs) - 1
+		}
 	}
 
 	m.focused = currentTabInputs[currentPos]


### PR DESCRIPTION
## Align add/edit form navigation behavior

I noticed that the add and edit forms were behaving differently, which was creating a confusing experience for users. In the add form, pressing Enter on the last field of the General tab would trigger the wrap-around logic, while the submit-on-last logic was actually bound to the Advanced tab - making the help label misleading. But in the edit form, the same action would switch you over to the Advanced tab instead.

To fix this inconsistency, I standardized both forms to follow the same navigation pattern. Now when you're on the General tab and press Enter on the last field, you'll naturally move to the Advanced tab. From there, pressing Enter on the last field will submit the form. This creates a the same flow as the edit form, where users progress through General → Advanced → Submit.

The change was made in `internal/ui/add_form.go:266-295` by updating the `handleNavigation()` function to match the edit form's behavior. I kept all the existing functionality intact - this is purely about making the user experience more consistent and intuitive.

Now users only need to learn one navigation pattern, and they'll discover the Advanced options before finalizing their submission. It's a small change that makes the whole interface feel more polished and predictable.

As a future improvement, it would be worth standardizing the help labels across both forms for complete consistency, though I didn't implement that as part of this change.