### PR TITLE
feat: add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ release/
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Nix
+result
+result-*
+.direnv
+.envrc.cache

--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ tar -xzf sshm-linux-amd64.tar.gz
 sudo mv sshm-linux-amd64 /usr/local/bin/sshm
 ```
 
+*Nix:*
+```bash
+# Try without installing
+nix run github:Gu1llaum-3/sshm
+
+# Install to profile
+nix profile install github:Gu1llaum-3/sshm
+```
+
+For flake configuration:
+```nix
+# add sshm to your flake inputs
+{
+  inputs.sshm.url = "github:Gu1llaum-3/sshm";
+}
+
+# and then add to your system packages:
+{
+  inputs.sshm.packages.${package.system}.default
+}
+
 *Windows:*
 ```powershell
 # Download and extract

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "SSHM - A modern, interactive SSH Manager for your terminal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "1.10.0";
+      in
+      {
+        packages = {
+          sshm = pkgs.buildGoModule {
+            pname = "sshm";
+            version = version;
+
+            src = ./.;
+
+            vendorHash = "sha256-aU/+bxcETs/Jq5FVAdiioyuc1AufvWeiqFQ7uo1cK1k=";
+
+            doCheck = false;
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${version}"
+            ];
+
+            nativeBuildInputs = [ pkgs.go ];
+
+            meta = with pkgs.lib; {
+              description = "A modern, interactive SSH Manager for your terminal";
+              homepage = "https://github.com/Gu1llaum-3/sshm";
+              license = licenses.mit;
+              platforms = platforms.unix ++ platforms.windows;
+            };
+          };
+
+          default = self.packages.${system}.sshm;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ pkgs.go ];
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.sshm}/bin/sshm";
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hello,

I suggest adding Nix support for the sshm project. This will allow Nix users to use sshm while waiting for the official package to be validated (I submitted a pull request to nixpkgs a while ago: [#449990](https://github.com/NixOS/nixpkgs/pull/449990)).

This also addresses the suggestion in issue #43.

Thanks!