### PR TITLE
feat(config): add focus_search_on_start option

### DIFF
--- a/internal/config/appconfig.go
+++ b/internal/config/appconfig.go
@@ -18,8 +18,9 @@ type KeyBindings struct {
 
 // AppConfig represents the main application configuration
 type AppConfig struct {
-	CheckForUpdates *bool       `json:"check_for_updates,omitempty"`
-	KeyBindings     KeyBindings `json:"key_bindings"`
+	CheckForUpdates    *bool       `json:"check_for_updates,omitempty"`
+	FocusSearchOnStart bool        `json:"focus_search_on_start"`
+	KeyBindings        KeyBindings `json:"key_bindings"`
 }
 
 // IsUpdateCheckEnabled returns true if the update check is enabled (default: true)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -32,6 +32,10 @@ func NewModel(hosts []config.SSHHost, configFile string, searchMode bool, curren
 		appConfig.CheckForUpdates = &f
 	}
 
+	if appConfig.FocusSearchOnStart {
+		searchMode = true
+	}
+
 	// Initialize the history manager
 	historyManager, err := history.NewHistoryManager()
 	if err != nil {


### PR DESCRIPTION
Hi! For users who always start with search, the `--search` flag shouldn't be required every time. This PR makes it possible to persist it.

- Add `focus_search_on_start` boolean option to `~/.config/sshm/config.json` (`false` by default)