### PR TITLE
[key-helper] feat: add end-to-end ssh key helper workflow for cli and tui

### DIFF
--- a/cmd/key.go
+++ b/cmd/key.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var keyCmd = &cobra.Command{
+	Use:   "key",
+	Short: "Manage SSH keys with local OpenSSH tools",
+	Long: `Manage SSH keys with local OpenSSH tools.
+
+SSHM never stores private keys or passphrases. It calls tools like
+ssh-keygen and ssh-add.`,
+}
+
+func init() {
+	RootCmd.AddCommand(keyCmd)
+}

--- a/cmd/key_add.go
+++ b/cmd/key_add.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	keycmd "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyAddAppleKeychain bool
+	keyAddDryRun        bool
+)
+
+var keyAddCmd = &cobra.Command{
+	Use:   "add <private-key>",
+	Short: "Add a private key to the local ssh-agent",
+	Long: `Add a private key to the local ssh-agent with ssh-add.
+
+SSHM leaves passphrase prompts and agent handling to the system ssh-add binary.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := keycmd.AddOptions{
+			Path:          args[0],
+			AppleKeychain: keyAddAppleKeychain,
+			DryRun:        keyAddDryRun,
+		}
+
+		path, addArgs, err := keycmd.Add(cmd.Context(), keycmd.ExecRunner{}, opts)
+		if err != nil {
+			return err
+		}
+
+		if keyAddDryRun {
+			fmt.Fprintf(cmd.OutOrStdout(), "Would run: ssh-add %s\n", shellJoin(addArgs))
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Added to ssh-agent: %s\n", path)
+		return nil
+	},
+}
+
+func init() {
+	keyCmd.AddCommand(keyAddCmd)
+
+	keyAddCmd.Flags().BoolVar(&keyAddAppleKeychain, "apple-keychain", false, "Use Apple's ssh-add keychain support when available")
+	keyAddCmd.Flags().BoolVar(&keyAddDryRun, "dry-run", false, "Show the ssh-add command without running it")
+}

--- a/cmd/key_attach.go
+++ b/cmd/key_attach.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	keycmd "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyAttachIdentity string
+	keyAttachDryRun   bool
+)
+
+var keyAttachCmd = &cobra.Command{
+	Use:   "attach <host>",
+	Short: "Attach a key to an existing SSH host",
+	Long: `Attach a key to an existing SSH host by setting IdentityFile.
+
+SSHM resolves the target host strictly. If the name is ambiguous or the block
+cannot be edited safely, attach stops.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := keycmd.Attach(cmd.Context(), keycmd.AttachOptions{
+			Host:       args[0],
+			Identity:   keyAttachIdentity,
+			ConfigPath: configFile,
+			DryRun:     keyAttachDryRun,
+		})
+		if err != nil {
+			return err
+		}
+
+		if result.AlreadyAttached {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s already uses %s\n", result.HostName, result.Identity)
+			return nil
+		}
+
+		if keyAttachDryRun {
+			fmt.Fprintf(cmd.OutOrStdout(), "Would attach %s to %s at %s:%d\n", result.Identity, result.HostName, result.SourceFile, result.Line)
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Attached %s to %s at %s:%d\n", result.Identity, result.HostName, result.SourceFile, result.Line)
+		return nil
+	},
+}
+
+func init() {
+	keyCmd.AddCommand(keyAttachCmd)
+
+	keyAttachCmd.Flags().StringVar(&keyAttachIdentity, "identity", "", "Private key path, or matching .pub path")
+	keyAttachCmd.Flags().BoolVar(&keyAttachDryRun, "dry-run", false, "Show the resolved target without writing config")
+	_ = keyAttachCmd.MarkFlagRequired("identity")
+}

--- a/cmd/key_deploy.go
+++ b/cmd/key_deploy.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+
+	keycmd "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyDeployIdentity string
+	keyDeployUser     string
+	keyDeployPort     string
+	keyDeployDryRun   bool
+)
+
+var keyDeployCmd = &cobra.Command{
+	Use:   "deploy <host-or-address>",
+	Short: "Copy a public key to a remote host",
+	Long: `Copy a public key to a remote host with OpenSSH tools.
+
+SSHM uses ssh-copy-id when available and falls back to an idempotent ssh flow
+when it is not.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := keycmd.DeployOptions{
+			Target:     args[0],
+			User:       keyDeployUser,
+			Port:       keyDeployPort,
+			Identity:   keyDeployIdentity,
+			ConfigPath: configFile,
+			DryRun:     keyDeployDryRun,
+		}
+
+		plan, err := keycmd.Deploy(cmd.Context(), keycmd.ExecRunner{}, opts)
+		if err != nil {
+			return err
+		}
+
+		if keyDeployDryRun {
+			fmt.Fprintf(cmd.OutOrStdout(), "Would run: %s %s\n", plan.Command, shellJoin(plan.Args))
+			fmt.Fprintf(cmd.OutOrStdout(), "Public key: %s\n", plan.PublicKeyPath)
+			fmt.Fprintf(cmd.OutOrStdout(), "Target: %s\n", plan.Target)
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Deployed %s to %s\n", plan.PublicKeyPath, plan.Target)
+		return nil
+	},
+}
+
+func init() {
+	keyCmd.AddCommand(keyDeployCmd)
+
+	keyDeployCmd.Flags().StringVar(&keyDeployIdentity, "identity", "", "Private key path, or matching .pub path")
+	keyDeployCmd.Flags().StringVar(&keyDeployUser, "user", "", "Remote SSH user (treat target as a direct host)")
+	keyDeployCmd.Flags().StringVar(&keyDeployPort, "port", "", "Remote SSH port (treat target as a direct host)")
+	keyDeployCmd.Flags().BoolVar(&keyDeployDryRun, "dry-run", false, "Show the deploy command without running it")
+	_ = keyDeployCmd.MarkFlagRequired("identity")
+}

--- a/cmd/key_gen.go
+++ b/cmd/key_gen.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	keycmd "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyGenName      string
+	keyGenAlgorithm string
+	keyGenComment   string
+	keyGenDirectory string
+	keyGenKDFRounds int
+	keyGenDryRun    bool
+)
+
+var keyGenCmd = &cobra.Command{
+	Use:   "gen",
+	Short: "Generate an SSH key pair with ssh-keygen",
+	Long: `Generate an SSH key pair with ssh-keygen.
+
+SSHM uses the system ssh-keygen binary and never handles passphrases itself.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := keycmd.GenerateOptions{
+			Name:      keyGenName,
+			Algorithm: keyGenAlgorithm,
+			Comment:   keyGenComment,
+			Directory: keyGenDirectory,
+			KDFRounds: keyGenKDFRounds,
+			DryRun:    keyGenDryRun,
+		}
+
+		result, genArgs, err := keycmd.BuildGenerateArgs(opts)
+		if err != nil {
+			return err
+		}
+
+		if keyGenDryRun {
+			fmt.Fprintf(cmd.OutOrStdout(), "Would run: ssh-keygen %s\n", shellJoin(genArgs))
+			fmt.Fprintf(cmd.OutOrStdout(), "Private: %s\n", result.PrivateKeyPath)
+			fmt.Fprintf(cmd.OutOrStdout(), "Public: %s\n", result.PublicKeyPath)
+			return nil
+		}
+
+		result, err = keycmd.Generate(cmd.Context(), keycmd.ExecRunner{}, opts)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Generated:\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "  Private: %s\n", result.PrivateKeyPath)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Public: %s\n", result.PublicKeyPath)
+		return nil
+	},
+}
+
+func shellJoin(args []string) string {
+	var quoted []string
+	for _, arg := range args {
+		if strings.ContainsAny(arg, " \t\n\"'") {
+			quoted = append(quoted, fmt.Sprintf("%q", arg))
+			continue
+		}
+		quoted = append(quoted, arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func init() {
+	keyCmd.AddCommand(keyGenCmd)
+
+	keyGenCmd.Flags().StringVar(&keyGenName, "name", "", "Key file name without .pub")
+	keyGenCmd.Flags().StringVar(&keyGenAlgorithm, "algo", "ed25519", fmt.Sprintf("Key algorithm passed to ssh-keygen (%s)", strings.Join(keycmd.AllowedGenerateAlgorithms(), ", ")))
+	keyGenCmd.Flags().StringVar(&keyGenComment, "comment", "", "Key comment")
+	keyGenCmd.Flags().StringVar(&keyGenDirectory, "path", "", "Directory for the new key pair (default: ~/.ssh)")
+	keyGenCmd.Flags().IntVar(&keyGenKDFRounds, "kdf-rounds", 100, "KDF rounds passed to ssh-keygen -a")
+	keyGenCmd.Flags().BoolVar(&keyGenDryRun, "dry-run", false, "Show the ssh-keygen command without running it")
+	_ = keyGenCmd.MarkFlagRequired("name")
+}

--- a/cmd/key_list.go
+++ b/cmd/key_list.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	keycmd "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/spf13/cobra"
+)
+
+var keyListJSON bool
+
+var keyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List local SSH keys and config references",
+	Long: `List local SSH keys and explicit ssh_config references.
+
+Only explicit IdentityFile entries are reported. SSHM does not resolve
+effective identities via ssh -G.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		items, err := keycmd.Inventory(cmd.Context(), keycmd.ExecRunner{}, configFile)
+		if err != nil {
+			return err
+		}
+
+		if keyListJSON {
+			data, err := json.MarshalIndent(items, "", "  ")
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return err
+		}
+
+		outputKeyInventoryTable(cmd, items)
+		return nil
+	},
+}
+
+func outputKeyInventoryTable(cmd *cobra.Command, items []keycmd.InventoryItem) {
+	if len(items) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No local SSH keys found.")
+		return
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "PATH\tMODE\tTYPE\tFINGERPRINT\tCONFIG HOSTS")
+	for _, item := range items {
+		hosts := "-"
+		if len(item.References) > 0 {
+			hostNames := make([]string, len(item.References))
+			for i := range item.References {
+				hostNames[i] = item.References[i].Host
+			}
+			hosts = strings.Join(hostNames, ", ")
+		}
+
+		keyType := item.Algorithm
+		if keyType == "" {
+			keyType = "-"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", item.Path, item.Permissions, keyType, item.Fingerprint, hosts)
+	}
+	_ = w.Flush()
+
+	label := "keys"
+	if len(items) == 1 {
+		label = "key"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nFound %d %s\n", len(items), label)
+}
+
+func init() {
+	keyCmd.AddCommand(keyListCmd)
+	keyListCmd.Flags().BoolVar(&keyListJSON, "json", false, "Print key inventory as JSON")
+}

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "testing"
+
+func TestKeyCommandRegistration(t *testing.T) {
+	found := false
+	for _, command := range RootCmd.Commands() {
+		if command.Name() == "key" {
+			found = true
+			if !command.HasSubCommands() {
+				t.Fatal("key command should register subcommands")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("key command not registered")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -45,7 +45,7 @@ func TestRootCommandFlags(t *testing.T) {
 func TestRootCommandSubcommands(t *testing.T) {
 	// Test that all expected subcommands are registered
 	// Note: completion and help are automatically added by Cobra and may not always appear in Commands()
-	expectedCommands := []string{"add", "edit", "search", "info"}
+	expectedCommands := []string{"add", "edit", "search", "info", "key"}
 
 	commands := RootCmd.Commands()
 	commandNames := make(map[string]bool)

--- a/internal/config/attach.go
+++ b/internal/config/attach.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// SetSSHHostIdentity updates the exact concrete host occurrence to use the given IdentityFile.
+// It fails closed for multi-host declarations and for blocks that contain multiple explicit
+// IdentityFile directives, because those shapes are not safe to rewrite generically.
+func SetSSHHostIdentity(host SSHHost, identity string) error {
+	if strings.TrimSpace(host.Name) == "" {
+		return fmt.Errorf("host name is required")
+	}
+	if strings.TrimSpace(host.SourceFile) == "" {
+		return fmt.Errorf("host '%s' has no source file", host.Name)
+	}
+	if host.LineNumber <= 0 {
+		return fmt.Errorf("host '%s' has no line number", host.Name)
+	}
+
+	normalizedIdentity, err := normalizeAttachedIdentity(identity)
+	if err != nil {
+		return err
+	}
+
+	configMutex.Lock()
+	defer configMutex.Unlock()
+
+	if err := backupConfig(host.SourceFile); err != nil {
+		return fmt.Errorf("failed to create backup: %w", err)
+	}
+
+	content, err := os.ReadFile(host.SourceFile)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	targetIdx := host.LineNumber - 1
+	if targetIdx < 0 || targetIdx >= len(lines) {
+		return fmt.Errorf("host '%s' line %d is out of range", host.Name, host.LineNumber)
+	}
+
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(lines[targetIdx])), "host ") {
+		return fmt.Errorf("line %d in %s is not a Host declaration", host.LineNumber, host.SourceFile)
+	}
+	hostNames := strings.Fields(strings.TrimSpace(lines[targetIdx])[5:])
+	if len(hostNames) > 1 {
+		return fmt.Errorf("host '%s' is part of a multi-host declaration; split it in Edit Host before attaching a key", host.Name)
+	}
+
+	blockEnd := len(lines)
+	for i := targetIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if isSSHSectionBoundary(trimmed) {
+			blockEnd = i
+			break
+		}
+	}
+
+	identityIndexes := make([]int, 0, 1)
+	for i := targetIdx + 1; i < blockEnd; i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if hasSSHDirective(trimmed, "identityfile") {
+			identityIndexes = append(identityIndexes, i)
+		}
+	}
+	if len(identityIndexes) > 1 {
+		return fmt.Errorf("host '%s' has multiple explicit IdentityFile directives; attach is blocked under current safety rules", host.Name)
+	}
+
+	identityLine := "    IdentityFile " + formatSSHConfigValue(normalizedIdentity)
+	switch len(identityIndexes) {
+	case 0:
+		insertAt := blockEnd
+		for insertAt > targetIdx+1 && strings.TrimSpace(lines[insertAt-1]) == "" {
+			insertAt--
+		}
+		lines = slices.Insert(lines, insertAt, identityLine)
+	case 1:
+		idx := identityIndexes[0]
+		indent := leadingWhitespace(lines[idx])
+		if indent == "" {
+			indent = "    "
+		}
+		lines[idx] = indent + "IdentityFile " + formatSSHConfigValue(normalizedIdentity)
+	}
+
+	return os.WriteFile(host.SourceFile, []byte(strings.Join(lines, "\n")), 0600)
+}
+
+func normalizeAttachedIdentity(identity string) (string, error) {
+	path := strings.TrimSpace(identity)
+	if path == "" {
+		return "", fmt.Errorf("identity path is required")
+	}
+	if strings.HasSuffix(path, ".pub") {
+		path = strings.TrimSuffix(path, ".pub")
+	}
+
+	expanded, err := expandSSHPath(path)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(expanded); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("private key not found: %s", expanded)
+		}
+		return "", err
+	}
+	return expanded, nil
+}
+
+// NormalizeAttachedIdentityForKey resolves an attach identity to an existing private-key path.
+func NormalizeAttachedIdentityForKey(identity string) (string, error) {
+	return normalizeAttachedIdentity(identity)
+}
+
+func expandSSHPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	path = strings.Trim(path, `"`)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	path = os.ExpandEnv(path)
+	path = expandWindowsHomeEnv(path)
+
+	if path == "~" {
+		homeDir, err := getHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = homeDir
+	} else if strings.HasPrefix(path, "~/") {
+		homeDir, err := getHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = filepath.Join(homeDir, strings.TrimPrefix(path, "~/"))
+	} else if strings.HasPrefix(path, `~\`) {
+		homeDir, err := getHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = filepath.Join(homeDir, strings.ReplaceAll(strings.TrimPrefix(path, `~\`), `\`, string(os.PathSeparator)))
+	}
+	return filepath.Clean(path), nil
+}
+
+func expandWindowsHomeEnv(path string) string {
+	const prefix = `%USERPROFILE%`
+	if len(path) < len(prefix) || !strings.EqualFold(path[:len(prefix)], prefix) {
+		return path
+	}
+
+	home := os.Getenv("USERPROFILE")
+	if home == "" {
+		return path
+	}
+
+	rest := strings.TrimLeft(path[len(prefix):], `\/`)
+	return filepath.Join(home, strings.ReplaceAll(rest, `\`, string(os.PathSeparator)))
+}
+
+func isSSHSectionBoundary(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	return strings.HasPrefix(lower, "host ") || strings.HasPrefix(lower, "match ")
+}
+
+func hasSSHDirective(line string, directive string) bool {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false
+	}
+	return strings.EqualFold(fields[0], directive)
+}
+
+func leadingWhitespace(line string) string {
+	idx := 0
+	for idx < len(line) {
+		if line[idx] != ' ' && line[idx] != '\t' {
+			break
+		}
+		idx++
+	}
+	return line[:idx]
+}

--- a/internal/config/attach_test.go
+++ b/internal/config/attach_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAttachedIdentityExpandsWindowsStyleHomePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	privateKey := filepath.Join(home, ".ssh", "id_ed25519_demo")
+	if err := os.MkdirAll(filepath.Dir(privateKey), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := NormalizeAttachedIdentityForKey(`~\.ssh\id_ed25519_demo`)
+	if err != nil {
+		t.Fatalf("NormalizeAttachedIdentityForKey() error = %v", err)
+	}
+	if got != privateKey {
+		t.Fatalf("path = %q, want %q", got, privateKey)
+	}
+}
+
+func TestNormalizeAttachedIdentityExpandsUserProfilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+
+	privateKey := filepath.Join(home, ".ssh", "id_ed25519_demo")
+	if err := os.MkdirAll(filepath.Dir(privateKey), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := NormalizeAttachedIdentityForKey(`%USERPROFILE%\.ssh\id_ed25519_demo`)
+	if err != nil {
+		t.Fatalf("NormalizeAttachedIdentityForKey() error = %v", err)
+	}
+	if got != privateKey {
+		t.Fatalf("path = %q, want %q", got, privateKey)
+	}
+}
+
+func TestNormalizeAttachedIdentityRejectsBlankPath(t *testing.T) {
+	_, err := NormalizeAttachedIdentityForKey("   ")
+	if err == nil {
+		t.Fatal("NormalizeAttachedIdentityForKey() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "identity path is required") {
+		t.Fatalf("error = %q, want identity path required", err)
+	}
+}
+
+func TestSetSSHHostIdentityStopsBeforeMatchBlock(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	content := `Host demo
+    HostName 203.0.113.10
+
+Match user root
+    IdentityFile ~/.ssh/id_match
+`
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	host := SSHHost{
+		Name:       "demo",
+		SourceFile: configPath,
+		LineNumber: 1,
+	}
+	if err := SetSSHHostIdentity(host, privateKey); err != nil {
+		t.Fatalf("SetSSHHostIdentity() error = %v", err)
+	}
+
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(updated)
+	if !strings.Contains(got, "Host demo\n    HostName 203.0.113.10\n    IdentityFile "+privateKey+"\n\nMatch user root") {
+		t.Fatalf("identity not inserted before Match block:\n%s", got)
+	}
+	if !strings.Contains(got, "Match user root\n    IdentityFile ~/.ssh/id_match") {
+		t.Fatalf("match block changed unexpectedly:\n%s", got)
+	}
+}

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -49,14 +49,7 @@ func GetDefaultSSHConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	switch runtime.GOOS {
-	case "windows":
-		return filepath.Join(homeDir, ".ssh", "config"), nil
-	default:
-		// Linux, macOS, etc.
-		return filepath.Join(homeDir, ".ssh", "config"), nil
-	}
+	return filepath.Join(homeDir, ".ssh", "config"), nil
 }
 
 // GetSSHMConfigDir returns the SSHM config directory
@@ -277,19 +270,7 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 			hosts = append(hosts, includeHosts...)
 		case "host":
 			// New host, save previous one if it exists
-			if currentHost != nil {
-				hosts = append(hosts, *currentHost)
-
-				// Handle aliases: create duplicate hosts for each alias
-				if len(currentHost.aliasNames) > 0 {
-					for _, aliasName := range currentHost.aliasNames {
-						aliasHost := *currentHost // Copy the host
-						aliasHost.Name = aliasName
-						aliasHost.aliasNames = nil // Clear temporary field
-						hosts = append(hosts, aliasHost)
-					}
-				}
-			}
+			hosts = appendParsedHost(hosts, currentHost)
 
 			// Parse multiple host names from the Host line
 			hostNames := strings.Fields(value)
@@ -328,6 +309,10 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 			}
 
 			// Clear pending tags for next host
+			pendingTags = nil
+		case "match":
+			hosts = appendParsedHost(hosts, currentHost)
+			currentHost = nil
 			pendingTags = nil
 		case "hostname":
 			if currentHost != nil {
@@ -375,23 +360,24 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 	}
 
 	// Add the last host if it exists
-	if currentHost != nil {
-		hosts = append(hosts, *currentHost)
-
-		// Handle aliases: create duplicate hosts for each alias
-		if len(currentHost.aliasNames) > 0 {
-			for _, aliasName := range currentHost.aliasNames {
-				aliasHost := *currentHost // Copy the host
-				aliasHost.Name = aliasName
-				aliasHost.aliasNames = nil // Clear temporary field
-				hosts = append(hosts, aliasHost)
-			}
-		}
-		// Clear the temporary field from the original
-		currentHost.aliasNames = nil
-	}
+	hosts = appendParsedHost(hosts, currentHost)
 
 	return hosts, scanner.Err()
+}
+
+func appendParsedHost(hosts []SSHHost, currentHost *SSHHost) []SSHHost {
+	if currentHost == nil {
+		return hosts
+	}
+
+	hosts = append(hosts, *currentHost)
+	for _, aliasName := range currentHost.aliasNames {
+		aliasHost := *currentHost
+		aliasHost.Name = aliasName
+		aliasHost.aliasNames = nil
+		hosts = append(hosts, aliasHost)
+	}
+	return hosts
 }
 
 // processIncludeDirective processes an Include directive and returns hosts from included files
@@ -681,11 +667,10 @@ func AddSSHHostToFile(host SSHHost, configPath string) error {
 // Input: "-o Compression=yes -o ServerAliveInterval=60" or "ForwardX11 true" or "Compression yes"
 // Output: "Compression yes\nServerAliveInterval 60"
 func ParseSSHOptionsFromCommand(options string) string {
+	options = strings.TrimSpace(options)
 	if options == "" {
 		return ""
 	}
-
-	options = strings.TrimSpace(options)
 
 	// If it doesn't contain -o, assume it's already in config format
 	if !strings.Contains(options, "-o") {
@@ -727,14 +712,14 @@ func ParseSSHOptionsFromCommand(options string) string {
 // Input: "Compression yes\nServerAliveInterval 60"
 // Output: "-o Compression=yes -o ServerAliveInterval=60"
 func FormatSSHOptionsForCommand(options string) string {
+	options = strings.TrimSpace(options)
 	if options == "" {
 		return ""
 	}
 
 	// If already in command format (starts with -o), return as is
-	trimmed := strings.TrimSpace(options)
-	if strings.HasPrefix(trimmed, "-o ") {
-		return trimmed
+	if strings.HasPrefix(options, "-o ") {
+		return options
 	}
 
 	var result []string
@@ -826,6 +811,31 @@ func GetSSHHost(hostName string) (*SSHHost, error) {
 	return nil, fmt.Errorf("host '%s' not found", hostName)
 }
 
+// LookupSSHHostsByName returns all concrete matches for a host name from the default SSH config graph.
+func LookupSSHHostsByName(hostName string) ([]SSHHost, error) {
+	configPath, err := GetDefaultSSHConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return LookupSSHHostsByNameFromFile(hostName, configPath)
+}
+
+// LookupSSHHostsByNameFromFile returns all concrete matches for a host name from a specific base config graph.
+func LookupSSHHostsByNameFromFile(hostName string, configPath string) ([]SSHHost, error) {
+	hosts, err := ParseSSHConfigFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]SSHHost, 0, 1)
+	for _, host := range hosts {
+		if host.Name == hostName {
+			matches = append(matches, host)
+		}
+	}
+	return matches, nil
+}
+
 // GetSSHHostFromFile retrieves a specific host configuration by name from a specific config file
 func GetSSHHostFromFile(hostName string, configPath string) (*SSHHost, error) {
 	hosts, err := ParseSSHConfigFile(configPath)
@@ -839,6 +849,32 @@ func GetSSHHostFromFile(hostName string, configPath string) (*SSHHost, error) {
 		}
 	}
 	return nil, fmt.Errorf("host '%s' not found", hostName)
+}
+
+// GetUniqueSSHHost returns one uniquely resolved host from the default SSH config graph.
+func GetUniqueSSHHost(hostName string) (*SSHHost, error) {
+	configPath, err := GetDefaultSSHConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return GetUniqueSSHHostFromFile(hostName, configPath)
+}
+
+// GetUniqueSSHHostFromFile returns one uniquely resolved host from a specific base config graph.
+// It fails closed when the name resolves to zero or multiple concrete matches.
+func GetUniqueSSHHostFromFile(hostName string, configPath string) (*SSHHost, error) {
+	matches, err := LookupSSHHostsByNameFromFile(hostName, configPath)
+	if err != nil {
+		return nil, err
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("host '%s' not found", hostName)
+	case 1:
+		return &matches[0], nil
+	default:
+		return nil, fmt.Errorf("host '%s' is ambiguous: %d matches found", hostName, len(matches))
+	}
 }
 
 // QuickHostExists performs a fast check if a host exists without full parsing

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -706,6 +706,143 @@ Include subdir/*.conf
 	}
 }
 
+func TestLookupSSHHostsByNameFromFileReturnsConcreteMatchesAcrossIncludes(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mainConfig := filepath.Join(tempDir, "config")
+	mainConfigContent := `Host shared
+    HostName primary.example.com
+
+Include included.conf
+`
+
+	if err := os.WriteFile(mainConfig, []byte(mainConfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create main config: %v", err)
+	}
+
+	includedConfig := filepath.Join(tempDir, "included.conf")
+	includedConfigContent := `Host shared
+    HostName included.example.com
+`
+
+	if err := os.WriteFile(includedConfig, []byte(includedConfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create included config: %v", err)
+	}
+
+	matches, err := LookupSSHHostsByNameFromFile("shared", mainConfig)
+	if err != nil {
+		t.Fatalf("LookupSSHHostsByNameFromFile() error = %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("len(matches) = %d, want 2", len(matches))
+	}
+
+	gotFiles := map[string]bool{}
+	gotHostnames := map[string]bool{}
+	for _, match := range matches {
+		gotFiles[match.SourceFile] = true
+		gotHostnames[match.Hostname] = true
+		if match.LineNumber <= 0 {
+			t.Fatalf("LineNumber = %d, want positive line number", match.LineNumber)
+		}
+	}
+
+	if !gotFiles[mainConfig] || !gotFiles[includedConfig] {
+		t.Fatalf("SourceFile set = %#v, want both %q and %q", gotFiles, mainConfig, includedConfig)
+	}
+	if !gotHostnames["primary.example.com"] || !gotHostnames["included.example.com"] {
+		t.Fatalf("Hostname set = %#v, want both concrete matches", gotHostnames)
+	}
+}
+
+func TestGetUniqueSSHHostFromFileRejectsAmbiguousMatches(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mainConfig := filepath.Join(tempDir, "config")
+	mainConfigContent := `Host shared
+    HostName primary.example.com
+
+Include included.conf
+`
+
+	if err := os.WriteFile(mainConfig, []byte(mainConfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create main config: %v", err)
+	}
+
+	includedConfig := filepath.Join(tempDir, "included.conf")
+	includedConfigContent := `Host shared
+    HostName included.example.com
+`
+
+	if err := os.WriteFile(includedConfig, []byte(includedConfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create included config: %v", err)
+	}
+
+	host, err := GetUniqueSSHHostFromFile("shared", mainConfig)
+	if err == nil {
+		t.Fatalf("GetUniqueSSHHostFromFile() error = nil, want ambiguity error")
+	}
+	if host != nil {
+		t.Fatalf("host = %#v, want nil on ambiguity", host)
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguity wording", err)
+	}
+}
+
+func TestGetUniqueSSHHostFromFileReturnsUniqueMatch(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mainConfig := filepath.Join(tempDir, "config")
+	mainConfigContent := `Host only
+    HostName unique.example.com
+    User deploy
+`
+
+	if err := os.WriteFile(mainConfig, []byte(mainConfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create main config: %v", err)
+	}
+
+	host, err := GetUniqueSSHHostFromFile("only", mainConfig)
+	if err != nil {
+		t.Fatalf("GetUniqueSSHHostFromFile() error = %v", err)
+	}
+	if host == nil {
+		t.Fatal("host = nil, want unique match")
+	}
+	if host.Hostname != "unique.example.com" || host.User != "deploy" {
+		t.Fatalf("host = %#v, want concrete unique match", host)
+	}
+	if host.SourceFile != mainConfig {
+		t.Fatalf("SourceFile = %q, want %q", host.SourceFile, mainConfig)
+	}
+}
+
+func TestParseSSHConfigDoesNotAttachMatchIdentityToHost(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	content := `Host demo
+    HostName 203.0.113.10
+
+Match user root
+    IdentityFile ~/.ssh/id_match
+`
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts, err := ParseSSHConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("ParseSSHConfigFile() error = %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("len(hosts) = %d, want 1", len(hosts))
+	}
+	if hosts[0].Identity != "" {
+		t.Fatalf("Identity = %q, want empty because Match block identity is not a Host declaration", hosts[0].Identity)
+	}
+}
+
 func TestGetAllConfigFilesFromBase(t *testing.T) {
 	// Create temporary directory for test files
 	tempDir := t.TempDir()

--- a/internal/key/agent.go
+++ b/internal/key/agent.go
@@ -1,0 +1,70 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// BuildAddArgs validates the key path and returns ssh-add arguments.
+func BuildAddArgs(path string) (string, []string, error) {
+	normalized, err := validateExistingPrivateKey(path)
+	if err != nil {
+		return "", nil, err
+	}
+	return normalized, []string{normalized}, nil
+}
+
+// SupportsAppleUseKeychain detects local support for Apple's ssh-add flag.
+func SupportsAppleUseKeychain(ctx context.Context, runner Runner) (bool, error) {
+	if runtime.GOOS != "darwin" {
+		return false, nil
+	}
+
+	out, err := runner.Output(ctx, "ssh-add", "--apple-use-keychain", "-l")
+	return appleUseKeychainProbeSupported(out, err)
+}
+
+func appleUseKeychainProbeSupported(out []byte, err error) (bool, error) {
+	lower := strings.ToLower(string(out))
+	if strings.Contains(lower, "illegal option") ||
+		strings.Contains(lower, "invalid option") ||
+		strings.Contains(lower, "unknown option") ||
+		strings.Contains(lower, "unrecognized option") ||
+		strings.Contains(lower, "usage:") {
+		return false, nil
+	}
+	if err != nil && strings.TrimSpace(lower) == "" {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// Add loads a private key into the local ssh-agent.
+func Add(ctx context.Context, runner Runner, opts AddOptions) (string, []string, error) {
+	normalized, args, err := BuildAddArgs(opts.Path)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if opts.AppleKeychain {
+		supported, err := SupportsAppleUseKeychain(ctx, runner)
+		if err != nil {
+			return "", nil, err
+		}
+		if !supported {
+			return "", nil, fmt.Errorf("--apple-keychain is not supported by the local ssh-add")
+		}
+		args = append([]string{"--apple-use-keychain"}, args...)
+	}
+
+	if !opts.DryRun {
+		if err := runner.Run(ctx, "ssh-add", args...); err != nil {
+			return "", nil, err
+		}
+	}
+
+	return normalized, args, nil
+}

--- a/internal/key/agent_test.go
+++ b/internal/key/agent_test.go
@@ -1,0 +1,163 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestBuildAddArgs(t *testing.T) {
+	privateKey := filepath.Join(t.TempDir(), "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, args, err := BuildAddArgs(privateKey)
+	if err != nil {
+		t.Fatalf("BuildAddArgs() error = %v", err)
+	}
+	if path != privateKey {
+		t.Fatalf("path = %q", path)
+	}
+	if !slices.Equal(args, []string{privateKey}) {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
+func TestBuildAddArgsExpandsWindowsStyleHomePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	privateKey := filepath.Join(home, ".ssh", "id_ed25519_demo")
+	if err := os.MkdirAll(filepath.Dir(privateKey), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, args, err := BuildAddArgs(`~\.ssh\id_ed25519_demo`)
+	if err != nil {
+		t.Fatalf("BuildAddArgs() error = %v", err)
+	}
+	if path != privateKey {
+		t.Fatalf("path = %q, want %q", path, privateKey)
+	}
+	if !slices.Equal(args, []string{privateKey}) {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
+func TestBuildAddArgsExpandsUserProfilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+
+	privateKey := filepath.Join(home, ".ssh", "id_ed25519_demo")
+	if err := os.MkdirAll(filepath.Dir(privateKey), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, _, err := BuildAddArgs(`%USERPROFILE%\.ssh\id_ed25519_demo`)
+	if err != nil {
+		t.Fatalf("BuildAddArgs() error = %v", err)
+	}
+	if path != privateKey {
+		t.Fatalf("path = %q, want %q", path, privateKey)
+	}
+}
+
+func TestBuildAddArgsRejectsBlankPath(t *testing.T) {
+	_, _, err := BuildAddArgs("   ")
+	if err == nil {
+		t.Fatal("BuildAddArgs() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "path is required") {
+		t.Fatalf("error = %q, want path required", err)
+	}
+}
+
+func TestAddDryRun(t *testing.T) {
+	privateKey := filepath.Join(t.TempDir(), "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		outputs: make(map[string][]byte),
+		errors:  make(map[string]error),
+	}
+
+	path, args, err := Add(context.Background(), runner, AddOptions{
+		Path:   privateKey,
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if path != privateKey {
+		t.Fatalf("path = %q", path)
+	}
+	if !slices.Equal(args, []string{privateKey}) {
+		t.Fatalf("args = %#v", args)
+	}
+	if len(runner.runCalls) != 0 {
+		t.Fatalf("runCalls = %#v, want none", runner.runCalls)
+	}
+}
+
+func TestSupportsAppleUseKeychain(t *testing.T) {
+	runner := &fakeRunner{
+		outputs: map[string][]byte{
+			"ssh-add --apple-use-keychain -l": []byte("Could not open a connection to your authentication agent.\n"),
+		},
+		errors: map[string]error{
+			"ssh-add --apple-use-keychain -l": fmt.Errorf("agent unavailable"),
+		},
+	}
+
+	supported, err := SupportsAppleUseKeychain(context.Background(), runner)
+	if runtime.GOOS == "darwin" {
+		if err != nil {
+			t.Fatalf("SupportsAppleUseKeychain() error = %v", err)
+		}
+		if !supported {
+			t.Fatal("expected support on darwin-compatible probe output")
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("SupportsAppleUseKeychain() error = %v", err)
+	}
+	if supported {
+		t.Fatal("expected no support outside darwin")
+	}
+}
+
+func TestAppleUseKeychainProbeRejectsUsageOutput(t *testing.T) {
+	supported, err := appleUseKeychainProbeSupported([]byte("usage: ssh-add [-cDdKkLlqvXx] [-E fingerprint_hash]\n"), fmt.Errorf("usage"))
+	if err != nil {
+		t.Fatalf("appleUseKeychainProbeSupported() error = %v", err)
+	}
+	if supported {
+		t.Fatal("supported = true, want false for generic usage output")
+	}
+}
+
+func TestAppleUseKeychainProbeAllowsAgentUnavailableOutput(t *testing.T) {
+	supported, err := appleUseKeychainProbeSupported([]byte("Could not open a connection to your authentication agent.\n"), fmt.Errorf("agent unavailable"))
+	if err != nil {
+		t.Fatalf("appleUseKeychainProbeSupported() error = %v", err)
+	}
+	if !supported {
+		t.Fatal("supported = false, want true for Apple-compatible probe output")
+	}
+}

--- a/internal/key/attach.go
+++ b/internal/key/attach.go
@@ -1,0 +1,82 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+)
+
+// Attach sets IdentityFile for a uniquely resolved host occurrence.
+func Attach(ctx context.Context, opts AttachOptions) (AttachResult, error) {
+	_ = ctx
+
+	hostName := strings.TrimSpace(opts.Host)
+	if hostName == "" {
+		return AttachResult{}, fmt.Errorf("host name is required")
+	}
+
+	host, err := resolveAttachTarget(hostName, opts.ConfigPath)
+	if err != nil {
+		return AttachResult{}, err
+	}
+	return AttachToConcreteHost(*host, opts.Identity, opts.DryRun)
+}
+
+// AttachToConcreteHost sets IdentityFile for one concrete host occurrence.
+func AttachToConcreteHost(host config.SSHHost, identity string, dryRun bool) (AttachResult, error) {
+	normalizedIdentity, err := configIdentityPath(identity)
+	if err != nil {
+		return AttachResult{}, err
+	}
+
+	result := AttachResult{
+		HostName:         host.Name,
+		Identity:         normalizedIdentity,
+		SourceFile:       host.SourceFile,
+		Line:             host.LineNumber,
+		DeclaredIdentity: strings.TrimSpace(host.Identity),
+	}
+	if sameIdentityDeclaration(host.Identity, normalizedIdentity) {
+		result.AlreadyAttached = true
+		return result, nil
+	}
+
+	if dryRun {
+		return result, nil
+	}
+
+	if err := config.SetSSHHostIdentity(host, normalizedIdentity); err != nil {
+		return AttachResult{}, err
+	}
+	return result, nil
+}
+
+func resolveAttachTarget(hostName string, configPath string) (*config.SSHHost, error) {
+	if configPath != "" {
+		return config.GetUniqueSSHHostFromFile(hostName, configPath)
+	}
+	return config.GetUniqueSSHHost(hostName)
+}
+
+func configIdentityPath(identity string) (string, error) {
+	normalized, err := config.NormalizeAttachedIdentityForKey(identity)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(normalized), nil
+}
+
+func sameIdentityDeclaration(declared string, normalizedIdentity string) bool {
+	trimmed := strings.TrimSpace(declared)
+	if trimmed == "" {
+		return false
+	}
+	normalizedDeclared, err := config.NormalizeAttachedIdentityForKey(trimmed)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(normalizedDeclared) == normalizedIdentity
+}

--- a/internal/key/attach_test.go
+++ b/internal/key/attach_test.go
@@ -1,0 +1,191 @@
+package key
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAttachSetsIdentityFileForUniqueHost(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	if err := os.WriteFile(configPath, []byte("Host demo\n    HostName 203.0.113.10\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("Attach() error = %v", err)
+	}
+	if result.HostName != "demo" {
+		t.Fatalf("HostName = %q, want demo", result.HostName)
+	}
+	if result.Identity != privateKey {
+		t.Fatalf("Identity = %q, want %q", result.Identity, privateKey)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "IdentityFile "+privateKey) {
+		t.Fatalf("config missing attached identity:\n%s", string(content))
+	}
+}
+
+func TestAttachAcceptsPubPathAndNormalizesToPrivateKey(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	if err := os.WriteFile(configPath, []byte("Host demo\n    HostName 203.0.113.10\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey+".pub", []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey + ".pub",
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("Attach() error = %v", err)
+	}
+	if result.Identity != privateKey {
+		t.Fatalf("Identity = %q, want %q", result.Identity, privateKey)
+	}
+}
+
+func TestAttachDryRunDoesNotWriteConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	original := "Host demo\n    HostName 203.0.113.10\n"
+	if err := os.WriteFile(configPath, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("Attach() error = %v", err)
+	}
+	if result.AlreadyAttached {
+		t.Fatalf("AlreadyAttached = true, want false")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != original {
+		t.Fatalf("config changed during dry-run:\n%s", string(content))
+	}
+}
+
+func TestAttachRejectsAmbiguousHost(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	if err := os.WriteFile(configPath, []byte("Host demo\n    HostName 203.0.113.10\nInclude extra.conf\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "extra.conf"), []byte("Host demo\n    HostName 203.0.113.11\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("Attach() error = nil, want ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguity wording", err)
+	}
+}
+
+func TestAttachRejectsMultiHostDeclaration(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	if err := os.WriteFile(configPath, []byte("Host demo demo-alt\n    HostName 203.0.113.10\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("Attach() error = nil, want multi-host rejection")
+	}
+	if !strings.Contains(err.Error(), "multi-host declaration") {
+		t.Fatalf("error = %q, want multi-host wording", err)
+	}
+}
+
+func TestAttachRejectsMultipleIdentityFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	content := `Host demo
+    HostName 203.0.113.10
+    IdentityFile ~/.ssh/id_one
+    IdentityFile ~/.ssh/id_two
+`
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Attach(context.Background(), AttachOptions{
+		Host:       "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("Attach() error = nil, want multiple IdentityFile rejection")
+	}
+	if !strings.Contains(err.Error(), "multiple explicit IdentityFile") {
+		t.Fatalf("error = %q, want multiple IdentityFile wording", err)
+	}
+}

--- a/internal/key/deploy.go
+++ b/internal/key/deploy.go
@@ -1,0 +1,211 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+	"github.com/Gu1llaum-3/sshm/internal/validation"
+)
+
+var hasSSHCopyID = func() bool {
+	_, err := exec.LookPath("ssh-copy-id")
+	return err == nil
+}
+
+type resolvedDeployTarget struct {
+	destination string
+	port        string
+	sshOptions  []string
+}
+
+// BuildDeployPlan validates deployment options and returns the concrete command plan.
+func BuildDeployPlan(opts DeployOptions) (DeployPlan, error) {
+	configPath := strings.TrimSpace(opts.ConfigPath)
+
+	target, err := resolveDeployTarget(opts)
+	if err != nil {
+		return DeployPlan{}, err
+	}
+
+	publicKeyPath, publicKey, err := resolvePublicKey(opts.Identity)
+	if err != nil {
+		return DeployPlan{}, err
+	}
+
+	if hasSSHCopyID() {
+		args := make([]string, 0, 10)
+		args = append(args, "-i", publicKeyPath)
+		if configPath != "" {
+			args = append(args, "-F", configPath)
+		}
+		if target.port != "" {
+			args = append(args, "-p", target.port)
+		}
+		args = appendSSHOptions(args, target.sshOptions)
+		args = append(args, target.destination)
+
+		return DeployPlan{
+			Command:       "ssh-copy-id",
+			Args:          args,
+			PublicKeyPath: publicKeyPath,
+			Target:        target.destination,
+		}, nil
+	}
+
+	quotedKey := shellSingleQuote(publicKey)
+	remoteScript := fmt.Sprintf(
+		"umask 077; mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && { grep -qxF %s ~/.ssh/authorized_keys || printf '%%s\\n' %s >> ~/.ssh/authorized_keys; }",
+		quotedKey,
+		quotedKey,
+	)
+
+	args := make([]string, 0, 12)
+	if configPath != "" {
+		args = append(args, "-F", configPath)
+	}
+	if target.port != "" {
+		args = append(args, "-p", target.port)
+	}
+	args = appendSSHOptions(args, target.sshOptions)
+	args = append(args, target.destination, "sh", "-c", remoteScript)
+
+	return DeployPlan{
+		Command:       "ssh",
+		Args:          args,
+		PublicKeyPath: publicKeyPath,
+		Target:        target.destination,
+	}, nil
+}
+
+// Deploy installs the selected public key onto the remote host using OpenSSH tooling.
+func Deploy(ctx context.Context, runner Runner, opts DeployOptions) (DeployPlan, error) {
+	plan, err := BuildDeployPlan(opts)
+	if err != nil {
+		return DeployPlan{}, err
+	}
+	if !opts.DryRun {
+		if err := runner.Run(ctx, plan.Command, plan.Args...); err != nil {
+			return DeployPlan{}, err
+		}
+	}
+	return plan, nil
+}
+
+func resolveDeployTarget(opts DeployOptions) (resolvedDeployTarget, error) {
+	target := strings.TrimSpace(opts.Target)
+	if target == "" {
+		return resolvedDeployTarget{}, fmt.Errorf("deploy target is required")
+	}
+
+	user := strings.TrimSpace(opts.User)
+	port := strings.TrimSpace(opts.Port)
+	proxyJump := strings.TrimSpace(opts.ProxyJump)
+	proxyCommand := strings.TrimSpace(opts.ProxyCommand)
+
+	if port != "" && !validation.ValidatePort(port) {
+		return resolvedDeployTarget{}, fmt.Errorf("port must be between 1 and 65535")
+	}
+
+	sshOptions := buildDeploySSHOptions(proxyJump, proxyCommand)
+
+	var (
+		matches []config.SSHHost
+		err     error
+	)
+	if strings.TrimSpace(opts.ConfigPath) != "" {
+		matches, err = config.LookupSSHHostsByNameFromFile(target, opts.ConfigPath)
+	} else {
+		matches, err = config.LookupSSHHostsByName(target)
+	}
+	if err != nil {
+		return resolvedDeployTarget{}, err
+	}
+
+	if len(matches) > 1 {
+		return resolvedDeployTarget{}, fmt.Errorf("host %q is ambiguous in ssh config: %d matches found", target, len(matches))
+	}
+
+	return resolvedDeployTarget{
+		destination: composeUserHost(user, target),
+		port:        port,
+		sshOptions:  sshOptions,
+	}, nil
+}
+
+func buildDeploySSHOptions(proxyJump string, proxyCommand string) []string {
+	options := make([]string, 0, 2)
+	if proxyJump != "" {
+		options = append(options, "ProxyJump="+proxyJump)
+	}
+	if proxyCommand != "" {
+		options = append(options, "ProxyCommand="+proxyCommand)
+	}
+	return options
+}
+
+func appendSSHOptions(args []string, options []string) []string {
+	for _, option := range options {
+		if strings.TrimSpace(option) == "" {
+			continue
+		}
+		args = append(args, "-o", option)
+	}
+	return args
+}
+
+func resolvePublicKey(identity string) (string, string, error) {
+	trimmed := strings.TrimSpace(identity)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("identity path is required")
+	}
+
+	expanded, err := expandPath(trimmed)
+	if err != nil {
+		return "", "", err
+	}
+
+	publicKeyPath := expanded
+	if !strings.HasSuffix(strings.ToLower(expanded), ".pub") {
+		privateKeyPath, err := validateExistingPrivateKey(expanded)
+		if err != nil {
+			return "", "", err
+		}
+		publicKeyPath = privateKeyPath + ".pub"
+	}
+
+	info, err := os.Stat(publicKeyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("stat public key %q: %w", publicKeyPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", "", fmt.Errorf("public key %q is not a regular file", publicKeyPath)
+	}
+
+	content, err := os.ReadFile(publicKeyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("read public key %q: %w", publicKeyPath, err)
+	}
+
+	publicKey := strings.TrimSpace(string(content))
+	if publicKey == "" {
+		return "", "", fmt.Errorf("public key %q is empty", publicKeyPath)
+	}
+
+	return filepath.Clean(publicKeyPath), publicKey, nil
+}
+
+func composeUserHost(user string, host string) string {
+	if strings.TrimSpace(user) == "" {
+		return host
+	}
+	return user + "@" + host
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}

--- a/internal/key/deploy_test.go
+++ b/internal/key/deploy_test.go
@@ -1,0 +1,279 @@
+package key
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildDeployPlanUsesSSHCopyIDForDirectTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return true }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	plan, err := BuildDeployPlan(DeployOptions{
+		Target:   "203.0.113.10",
+		User:     "root",
+		Port:     "2222",
+		Identity: privateKey,
+	})
+	if err != nil {
+		t.Fatalf("BuildDeployPlan() error = %v", err)
+	}
+	if plan.Command != "ssh-copy-id" {
+		t.Fatalf("command = %q, want ssh-copy-id", plan.Command)
+	}
+	want := []string{"-i", publicKey, "-p", "2222", "root@203.0.113.10"}
+	if got := shellCall(plan.Args); got != shellCall(want) {
+		t.Fatalf("args = %#v, want %#v", plan.Args, want)
+	}
+}
+
+func TestBuildDeployPlanUsesConfigAliasWhenUnique(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	configContent := `Host demo
+    HostName 203.0.113.10
+    User deploy
+    Port 2222
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return true }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	plan, err := BuildDeployPlan(DeployOptions{
+		Target:     "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("BuildDeployPlan() error = %v", err)
+	}
+	want := []string{"-i", publicKey, "-F", configPath, "demo"}
+	if got := shellCall(plan.Args); got != shellCall(want) {
+		t.Fatalf("args = %#v, want %#v", plan.Args, want)
+	}
+}
+
+func TestBuildDeployPlanKeepsConfigWhenDirectOverridesAreSet(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	configContent := `Host demo
+    HostName 203.0.113.10
+    User deploy
+    Port 2222
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return true }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	plan, err := BuildDeployPlan(DeployOptions{
+		Target:     "demo",
+		User:       "root",
+		Port:       "2200",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("BuildDeployPlan() error = %v", err)
+	}
+	want := []string{"-i", publicKey, "-F", configPath, "-p", "2200", "root@demo"}
+	if got := shellCall(plan.Args); got != shellCall(want) {
+		t.Fatalf("args = %#v, want %#v", plan.Args, want)
+	}
+}
+
+func TestBuildDeployPlanRejectsAmbiguousConfigAlias(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+	configContent := `Host demo
+    HostName 203.0.113.10
+
+Include included.conf
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "included.conf"), []byte("Host demo\n    HostName 203.0.113.11\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BuildDeployPlan(DeployOptions{
+		Target:     "demo",
+		Identity:   privateKey,
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		t.Fatal("BuildDeployPlan() error = nil, want ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguity wording", err)
+	}
+}
+
+func TestBuildDeployPlanFallsBackToManualSSH(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return false }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	plan, err := BuildDeployPlan(DeployOptions{
+		Target:   "203.0.113.10",
+		User:     "root",
+		Port:     "2200",
+		Identity: privateKey,
+	})
+	if err != nil {
+		t.Fatalf("BuildDeployPlan() error = %v", err)
+	}
+	if plan.Command != "ssh" {
+		t.Fatalf("command = %q, want ssh", plan.Command)
+	}
+	if got, want := plan.Args[0], "-p"; got != want {
+		t.Fatalf("args[0] = %q, want %q", got, want)
+	}
+	if !strings.Contains(shellCall(plan.Args), "grep -qxF 'ssh-ed25519 AAAATEST demo' ~/.ssh/authorized_keys") {
+		t.Fatalf("manual ssh command missing idempotent grep:\n%#v", plan.Args)
+	}
+}
+
+func TestBuildDeployPlanIncludesProxyOptionsForDirectTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return true }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	plan, err := BuildDeployPlan(DeployOptions{
+		Target:       "203.0.113.10",
+		User:         "root",
+		Port:         "2222",
+		ProxyJump:    "bastion",
+		ProxyCommand: "ssh -W %h:%p jump-host",
+		Identity:     privateKey,
+	})
+	if err != nil {
+		t.Fatalf("BuildDeployPlan() error = %v", err)
+	}
+
+	got := shellCall(plan.Args)
+	if !strings.Contains(got, "-o ProxyJump=bastion") {
+		t.Fatalf("args missing ProxyJump option: %#v", plan.Args)
+	}
+	if !strings.Contains(got, "-o ProxyCommand=ssh -W %h:%p jump-host") {
+		t.Fatalf("args missing ProxyCommand option: %#v", plan.Args)
+	}
+}
+
+func TestDeployDryRunDoesNotExecute(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKey := filepath.Join(tempDir, "id_ed25519_demo")
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := hasSSHCopyID
+	hasSSHCopyID = func() bool { return true }
+	t.Cleanup(func() {
+		hasSSHCopyID = original
+	})
+
+	runner := &fakeRunner{
+		outputs: make(map[string][]byte),
+		errors:  make(map[string]error),
+	}
+
+	plan, err := Deploy(context.Background(), runner, DeployOptions{
+		Target:   "203.0.113.10",
+		User:     "root",
+		Identity: privateKey,
+		DryRun:   true,
+	})
+	if err != nil {
+		t.Fatalf("Deploy() error = %v", err)
+	}
+	if plan.Command != "ssh-copy-id" {
+		t.Fatalf("command = %q, want ssh-copy-id", plan.Command)
+	}
+	if len(runner.runCalls) != 0 {
+		t.Fatalf("runCalls = %#v, want none", runner.runCalls)
+	}
+}

--- a/internal/key/exec.go
+++ b/internal/key/exec.go
@@ -1,0 +1,25 @@
+package key
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+// ExecRunner runs commands against the local system.
+type ExecRunner struct{}
+
+// Output returns combined command output.
+func (ExecRunner) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+// Run executes a command interactively with inherited stdio.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/key/generate.go
+++ b/internal/key/generate.go
@@ -1,0 +1,96 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+var allowedGenerateAlgorithms = []string{"ed25519", "ecdsa", "rsa"}
+
+func AllowedGenerateAlgorithms() []string {
+	return slices.Clone(allowedGenerateAlgorithms)
+}
+
+func NormalizeGenerateAlgorithm(value string) (string, error) {
+	algorithm := strings.ToLower(strings.TrimSpace(value))
+	if algorithm == "" {
+		return "ed25519", nil
+	}
+	if slices.Contains(allowedGenerateAlgorithms, algorithm) {
+		return algorithm, nil
+	}
+	return "", fmt.Errorf("algorithm must be one of: %s", strings.Join(allowedGenerateAlgorithms, ", "))
+}
+
+// BuildGenerateArgs validates options and returns ssh-keygen arguments.
+func BuildGenerateArgs(opts GenerateOptions) (GenerateResult, []string, error) {
+	name := strings.TrimSpace(opts.Name)
+	if name == "" {
+		return GenerateResult{}, nil, fmt.Errorf("key name is required")
+	}
+	if filepath.Base(name) != name || strings.ContainsAny(name, `/\`) {
+		return GenerateResult{}, nil, fmt.Errorf("key name must be a file name, not a path")
+	}
+
+	directory := opts.Directory
+	if strings.TrimSpace(directory) == "" {
+		var err error
+		directory, err = defaultSSHDirectory()
+		if err != nil {
+			return GenerateResult{}, nil, err
+		}
+	}
+
+	directory, err := expandPath(directory)
+	if err != nil {
+		return GenerateResult{}, nil, err
+	}
+
+	privateKeyPath := filepath.Join(directory, name)
+	if _, err := os.Stat(privateKeyPath); err == nil {
+		return GenerateResult{}, nil, fmt.Errorf("key %q already exists", privateKeyPath)
+	} else if !os.IsNotExist(err) {
+		return GenerateResult{}, nil, fmt.Errorf("stat key %q: %w", privateKeyPath, err)
+	}
+
+	algorithm, err := NormalizeGenerateAlgorithm(opts.Algorithm)
+	if err != nil {
+		return GenerateResult{}, nil, err
+	}
+
+	args := []string{"-t", algorithm, "-f", privateKeyPath}
+	if opts.Comment != "" {
+		args = append(args, "-C", opts.Comment)
+	}
+	if opts.KDFRounds > 0 {
+		args = append(args, "-a", fmt.Sprintf("%d", opts.KDFRounds))
+	}
+
+	return GenerateResult{
+		PrivateKeyPath: privateKeyPath,
+		PublicKeyPath:  privateKeyPath + ".pub",
+	}, args, nil
+}
+
+// Generate executes ssh-keygen with validated options.
+func Generate(ctx context.Context, runner Runner, opts GenerateOptions) (GenerateResult, error) {
+	result, args, err := BuildGenerateArgs(opts)
+	if err != nil {
+		return GenerateResult{}, err
+	}
+
+	if !opts.DryRun {
+		if err := os.MkdirAll(filepath.Dir(result.PrivateKeyPath), 0700); err != nil {
+			return GenerateResult{}, fmt.Errorf("create key directory: %w", err)
+		}
+		if err := runner.Run(ctx, "ssh-keygen", args...); err != nil {
+			return GenerateResult{}, err
+		}
+	}
+
+	return result, nil
+}

--- a/internal/key/generate_test.go
+++ b/internal/key/generate_test.go
@@ -1,0 +1,106 @@
+package key
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestBuildGenerateArgs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	result, args, err := BuildGenerateArgs(GenerateOptions{
+		Name:      "id_ed25519_demo",
+		Algorithm: "ed25519",
+		Comment:   "demo@test",
+		Directory: "~/.ssh",
+		KDFRounds: 100,
+	})
+	if err != nil {
+		t.Fatalf("BuildGenerateArgs() error = %v", err)
+	}
+
+	privatePath := filepath.Join(home, ".ssh", "id_ed25519_demo")
+	if result.PrivateKeyPath != privatePath {
+		t.Fatalf("private path = %q", result.PrivateKeyPath)
+	}
+	want := []string{"-t", "ed25519", "-f", privatePath, "-C", "demo@test", "-a", "100"}
+	if !slices.Equal(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
+func TestBuildGenerateArgsNormalizesAlgorithmCase(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, args, err := BuildGenerateArgs(GenerateOptions{
+		Name:      "id_rsa_demo",
+		Algorithm: "RSA",
+		Directory: "~/.ssh",
+	})
+	if err != nil {
+		t.Fatalf("BuildGenerateArgs() error = %v", err)
+	}
+	if got, want := args[1], "rsa"; got != want {
+		t.Fatalf("algorithm arg = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateDryRunDoesNotExecute(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	runner := &fakeRunner{
+		outputs: make(map[string][]byte),
+		errors:  make(map[string]error),
+	}
+
+	_, err := Generate(context.Background(), runner, GenerateOptions{
+		Name:   "id_ed25519_demo",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if len(runner.runCalls) != 0 {
+		t.Fatalf("runCalls = %#v, want none", runner.runCalls)
+	}
+}
+
+func TestBuildGenerateArgsRejectsUnsupportedAlgorithm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, _, err := BuildGenerateArgs(GenerateOptions{
+		Name:      "id_demo",
+		Algorithm: "dsa",
+		Directory: "~/.ssh",
+	})
+	if err == nil {
+		t.Fatal("BuildGenerateArgs() error = nil, want validation error")
+	}
+}
+
+func TestBuildGenerateArgsRejectsPathLikeName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, _, err := BuildGenerateArgs(GenerateOptions{
+		Name:      "nested/id_demo",
+		Directory: "~/.ssh",
+	})
+	if err == nil {
+		t.Fatal("BuildGenerateArgs() error = nil, want path-like name validation error")
+	}
+
+	_, _, err = BuildGenerateArgs(GenerateOptions{
+		Name:      `nested\id_demo`,
+		Directory: "~/.ssh",
+	})
+	if err == nil {
+		t.Fatal("BuildGenerateArgs() error = nil, want Windows path-like name validation error")
+	}
+}

--- a/internal/key/inventory.go
+++ b/internal/key/inventory.go
@@ -1,0 +1,141 @@
+package key
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+)
+
+// Inventory returns local key files plus explicit ssh_config references.
+func Inventory(ctx context.Context, runner Runner, configPath string) ([]InventoryItem, error) {
+	sshDir, err := defaultSSHDirectory()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(sshDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read ssh directory: %w", err)
+	}
+
+	references, err := loadDeclaredReferences(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]InventoryItem, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || isIgnoredSSHFile(entry.Name()) {
+			continue
+		}
+
+		path := filepath.Join(sshDir, entry.Name())
+		info, err := os.Stat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		out, err := runner.Output(ctx, "ssh-keygen", "-lf", path)
+		if err != nil {
+			continue
+		}
+
+		fingerprint, algorithm := parseFingerprintOutput(string(out))
+		if fingerprint == "" {
+			continue
+		}
+
+		normalized := filepath.Clean(path)
+		publicKeyPath := ""
+		if info, err := os.Stat(normalized + ".pub"); err == nil && info.Mode().IsRegular() {
+			publicKeyPath = normalized + ".pub"
+		}
+
+		refs := slices.Clone(references[normalized])
+		items = append(items, InventoryItem{
+			Path:          normalized,
+			PublicKeyPath: publicKeyPath,
+			Permissions:   permissionString(info.Mode()),
+			Fingerprint:   fingerprint,
+			Algorithm:     algorithm,
+			References:    refs,
+			CanDelete:     len(refs) == 0,
+		})
+	}
+
+	slices.SortFunc(items, func(a, b InventoryItem) int {
+		return cmp.Compare(a.Path, b.Path)
+	})
+
+	return items, nil
+}
+
+func loadDeclaredReferences(configPath string) (map[string][]Reference, error) {
+	var (
+		hosts []config.SSHHost
+		err   error
+	)
+
+	if configPath == "" {
+		hosts, err = config.ParseSSHConfig()
+	} else {
+		hosts, err = config.ParseSSHConfigFile(configPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("parse ssh config: %w", err)
+	}
+
+	references := make(map[string][]Reference)
+	for _, host := range hosts {
+		normalized, ok := normalizeDeclaredIdentity(host.Identity)
+		if !ok {
+			continue
+		}
+
+		references[normalized] = append(references[normalized], Reference{
+			Host:                 host.Name,
+			SourceFile:           host.SourceFile,
+			Line:                 host.LineNumber,
+			DeclaredIdentityFile: strings.TrimSpace(host.Identity),
+		})
+	}
+
+	for path, refs := range references {
+		slices.SortFunc(refs, func(a, b Reference) int {
+			if diff := cmp.Compare(a.Host, b.Host); diff != 0 {
+				return diff
+			}
+			if diff := cmp.Compare(a.SourceFile, b.SourceFile); diff != 0 {
+				return diff
+			}
+			return cmp.Compare(a.Line, b.Line)
+		})
+		references[path] = refs
+	}
+
+	return references, nil
+}
+
+func parseFingerprintOutput(out string) (fingerprint string, algorithm string) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) < 2 {
+		return "", ""
+	}
+
+	fingerprint = fields[1]
+	last := fields[len(fields)-1]
+	if strings.HasPrefix(last, "(") && strings.HasSuffix(last, ")") {
+		algorithm = strings.TrimSuffix(strings.TrimPrefix(last, "("), ")")
+	}
+
+	return fingerprint, algorithm
+}

--- a/internal/key/inventory_test.go
+++ b/internal/key/inventory_test.go
@@ -1,0 +1,166 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeRunner struct {
+	outputs  map[string][]byte
+	errors   map[string]error
+	runCalls []string
+}
+
+func (f *fakeRunner) Output(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := name + " " + shellCall(args)
+	if out, ok := f.outputs[call]; ok {
+		return out, f.errors[call]
+	}
+	return nil, fmt.Errorf("unexpected output call: %s", call)
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) error {
+	call := name + " " + shellCall(args)
+	f.runCalls = append(f.runCalls, call)
+	return f.errors[call]
+}
+
+func shellCall(args []string) string {
+	return strings.Join(args, " ")
+}
+
+func TestInventoryReturnsDeclaredReferencesOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(sshDir, "id_ed25519_test")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateKey+".pub", []byte("public"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte("ignored"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := filepath.Join(home, "ssh_config")
+	configContent := `Host demo
+    HostName example.com
+    IdentityFile ~/.ssh/id_ed25519_test
+
+Host effective-only
+    HostName example.net
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		outputs: map[string][]byte{
+			"ssh-keygen -lf " + privateKey: []byte("256 SHA256:testfingerprint " + privateKey + " (ED25519)\n"),
+		},
+		errors: make(map[string]error),
+	}
+
+	items, err := Inventory(context.Background(), runner, configPath)
+	if err != nil {
+		t.Fatalf("Inventory() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	if items[0].Path != privateKey {
+		t.Fatalf("path = %q", items[0].Path)
+	}
+	if items[0].Fingerprint != "SHA256:testfingerprint" {
+		t.Fatalf("fingerprint = %q", items[0].Fingerprint)
+	}
+	if items[0].Algorithm != "ED25519" {
+		t.Fatalf("algorithm = %q", items[0].Algorithm)
+	}
+	if items[0].PublicKeyPath != privateKey+".pub" {
+		t.Fatalf("public key path = %q", items[0].PublicKeyPath)
+	}
+	if len(items[0].References) != 1 || items[0].References[0].Host != "demo" {
+		t.Fatalf("references = %#v", items[0].References)
+	}
+	if items[0].CanDelete {
+		t.Fatalf("CanDelete = true, want false when declared references exist")
+	}
+}
+
+func TestInventorySkipsFilesWithoutFingerprint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(sshDir, "id_ed25519_test")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		outputs: map[string][]byte{},
+		errors: map[string]error{
+			"ssh-keygen -lf " + privateKey: fmt.Errorf("fingerprint failed"),
+		},
+	}
+
+	items, err := Inventory(context.Background(), runner, "")
+	if err != nil {
+		t.Fatalf("Inventory() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestInventoryMarksKeyAsDeletableWhenNoDeclaredReferencesExist(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := filepath.Join(sshDir, "id_ed25519_free")
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		outputs: map[string][]byte{
+			"ssh-keygen -lf " + privateKey: []byte("256 SHA256:freefingerprint " + privateKey + " (ED25519)\n"),
+		},
+		errors: make(map[string]error),
+	}
+
+	items, err := Inventory(context.Background(), runner, "")
+	if err != nil {
+		t.Fatalf("Inventory() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	if !items[0].CanDelete {
+		t.Fatalf("CanDelete = false, want true when no declared references exist")
+	}
+	if items[0].PublicKeyPath != "" {
+		t.Fatalf("public key path = %q, want empty when .pub file is missing", items[0].PublicKeyPath)
+	}
+}

--- a/internal/key/paths.go
+++ b/internal/key/paths.go
@@ -1,0 +1,147 @@
+package key
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+)
+
+var sshTokenPattern = regexp.MustCompile(`%[hprunCdiklLT]`)
+
+var ignoredSSHFileSuffixes = [...]string{
+	".pub",
+	".backup",
+	".bak",
+	".tmp",
+	".temp",
+	".orig",
+	".old",
+	".log",
+	".txt",
+	".json",
+	".md",
+	".crt",
+	".cer",
+}
+
+func defaultSSHDirectory() (string, error) {
+	return config.GetSSHDirectory()
+}
+
+func expandPath(path string) (string, error) {
+	expanded := strings.TrimSpace(path)
+	expanded = strings.Trim(expanded, `"`)
+	if expanded == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	expanded = os.ExpandEnv(expanded)
+	expanded = expandWindowsHomeEnv(expanded)
+
+	switch {
+	case expanded == "~":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		expanded = homeDir
+	case strings.HasPrefix(expanded, "~/"):
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		expanded = filepath.Join(homeDir, expanded[2:])
+	case strings.HasPrefix(expanded, `~\`):
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		expanded = filepath.Join(homeDir, strings.ReplaceAll(expanded[2:], `\`, string(os.PathSeparator)))
+	}
+
+	return filepath.Clean(expanded), nil
+}
+
+func expandWindowsHomeEnv(path string) string {
+	const prefix = `%USERPROFILE%`
+	if len(path) < len(prefix) || !strings.EqualFold(path[:len(prefix)], prefix) {
+		return path
+	}
+
+	home := os.Getenv("USERPROFILE")
+	if home == "" {
+		return path
+	}
+
+	rest := strings.TrimLeft(path[len(prefix):], `\/`)
+	return filepath.Join(home, strings.ReplaceAll(rest, `\`, string(os.PathSeparator)))
+}
+
+func normalizeDeclaredIdentity(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" || sshTokenPattern.MatchString(path) {
+		return "", false
+	}
+
+	expanded, err := expandPath(path)
+	if err != nil {
+		return "", false
+	}
+
+	if !filepath.IsAbs(expanded) {
+		return "", false
+	}
+
+	return expanded, true
+}
+
+func validateExistingPrivateKey(path string) (string, error) {
+	expanded, err := expandPath(path)
+	if err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(expanded)
+	if err != nil {
+		return "", fmt.Errorf("stat key %q: %w", expanded, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("key %q is not a regular file", expanded)
+	}
+	if strings.HasSuffix(strings.ToLower(expanded), ".pub") {
+		return "", fmt.Errorf("expected a private key, got public key path %q", expanded)
+	}
+
+	return expanded, nil
+}
+
+func isIgnoredSSHFile(name string) bool {
+	lower := strings.ToLower(name)
+	switch lower {
+	case "config",
+		"known_hosts",
+		"known_hosts.old",
+		"authorized_keys",
+		"authorized_keys.old",
+		"environment",
+		"allowed_signers",
+		".ds_store":
+		return true
+	}
+
+	for _, suffix := range ignoredSSHFileSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func permissionString(mode os.FileMode) string {
+	return fmt.Sprintf("%04o", mode.Perm())
+}

--- a/internal/key/types.go
+++ b/internal/key/types.go
@@ -1,0 +1,89 @@
+package key
+
+import "context"
+
+// Runner abstracts local subprocess execution for OpenSSH tooling.
+type Runner interface {
+	Output(ctx context.Context, name string, args ...string) ([]byte, error)
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+// Reference describes an explicit IdentityFile declaration in ssh_config.
+type Reference struct {
+	Host                 string `json:"host"`
+	SourceFile           string `json:"source_file,omitempty"`
+	Line                 int    `json:"line,omitempty"`
+	DeclaredIdentityFile string `json:"declared_identity_file,omitempty"`
+}
+
+// InventoryItem describes a local key file plus explicit config references.
+type InventoryItem struct {
+	Path          string      `json:"path"`
+	PublicKeyPath string      `json:"public_key_path,omitempty"`
+	Permissions   string      `json:"permissions"`
+	Fingerprint   string      `json:"fingerprint"`
+	Algorithm     string      `json:"algorithm,omitempty"`
+	References    []Reference `json:"references,omitempty"`
+	CanDelete     bool        `json:"can_delete"`
+}
+
+// GenerateOptions controls ssh-keygen invocation.
+type GenerateOptions struct {
+	Name      string
+	Algorithm string
+	Comment   string
+	Directory string
+	KDFRounds int
+	DryRun    bool
+}
+
+// GenerateResult reports generated file paths.
+type GenerateResult struct {
+	PrivateKeyPath string
+	PublicKeyPath  string
+}
+
+// AddOptions controls ssh-add invocation.
+type AddOptions struct {
+	Path          string
+	AppleKeychain bool
+	DryRun        bool
+}
+
+// DeployOptions controls public-key deployment to a remote host.
+type DeployOptions struct {
+	Target       string
+	User         string
+	Port         string
+	ProxyJump    string
+	ProxyCommand string
+	Identity     string
+	ConfigPath   string
+	DryRun       bool
+}
+
+// DeployPlan describes the concrete local command SSHM will execute.
+type DeployPlan struct {
+	Command       string
+	Args          []string
+	PublicKeyPath string
+	Target        string
+}
+
+// AttachOptions controls IdentityFile attachment to an existing host block.
+type AttachOptions struct {
+	Host       string
+	Identity   string
+	ConfigPath string
+	DryRun     bool
+}
+
+// AttachResult reports the concrete host occurrence that was updated.
+type AttachResult struct {
+	HostName         string
+	Identity         string
+	SourceFile       string
+	Line             int
+	AlreadyAttached  bool
+	DeclaredIdentity string
+}

--- a/internal/ui/add_form.go
+++ b/internal/ui/add_form.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Gu1llaum-3/sshm/internal/config"
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
 	"github.com/Gu1llaum-3/sshm/internal/validation"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -24,6 +26,13 @@ type addFormModel struct {
 	width      int
 	height     int
 	configFile string
+	keyPicker  *keyPickerModel
+	keyCreate  *keyCreateFormModel
+}
+
+type addFormField struct {
+	index int
+	label string
 }
 
 // NewAddForm creates a new add form model
@@ -152,19 +161,98 @@ const (
 	requestTTYInput
 )
 
+var (
+	addGeneralInputs  = [...]int{nameInput, hostnameInput, userInput, portInput, identityInput, proxyJumpInput, proxyCommandInput, tagsInput}
+	addAdvancedInputs = [...]int{optionsInput, remoteCommandInput, requestTTYInput}
+)
+
 // Messages for communication with parent model
 type addFormSubmitMsg struct {
 	hostname string
 	err      error
 }
 
+type addFormDeployFinishedMsg struct {
+	err error
+}
+
 type addFormCancelMsg struct{}
+
+var runAddFormDeploy = func(opts keypkg.DeployOptions) tea.Cmd {
+	return runUIDeployCommand(opts, func(err error) tea.Msg {
+		return addFormDeployFinishedMsg{err: err}
+	})
+}
 
 func (m *addFormModel) Init() tea.Cmd {
 	return textinput.Blink
 }
 
 func (m *addFormModel) Update(msg tea.Msg) (*addFormModel, tea.Cmd) {
+	if m.keyCreate != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.keyCreate.width = m.width
+			m.keyCreate.height = m.height
+			m.keyCreate.styles = m.styles
+			return m, nil
+		case keyCreateFinishedMsg:
+			if msg.err != nil {
+				m.keyCreate.err = msg.err.Error()
+				return m, nil
+			}
+			m.keyCreate = nil
+			m.inputs[identityInput].SetValue(msg.path)
+			m.focused = identityInput
+			m.currentTab = tabGeneral
+			return m, m.updateFocus()
+		case keyCreateCancelMsg:
+			m.keyCreate = nil
+			m.focused = identityInput
+			m.currentTab = tabGeneral
+			return m, m.updateFocus()
+		}
+
+		newForm, cmd := m.keyCreate.Update(msg)
+		m.keyCreate = newForm
+		return m, cmd
+	}
+
+	if m.keyPicker != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.keyPicker.width = m.width
+			m.keyPicker.height = m.height
+			m.keyPicker.styles = m.styles
+			return m, nil
+		case keyPickerSelectMsg:
+			m.keyPicker = nil
+			m.inputs[identityInput].SetValue(msg.path)
+			m.focused = identityInput
+			m.currentTab = tabGeneral
+			return m, m.updateFocus()
+		case keyPickerCancelMsg:
+			m.keyPicker = nil
+			m.focused = identityInput
+			m.currentTab = tabGeneral
+			return m, m.updateFocus()
+		case keyPickerCreateMsg:
+			m.keyPicker = nil
+			m.keyCreate = NewKeyCreateForm(m.styles, m.width, m.height)
+			return m, m.keyCreate.Init()
+		}
+
+		newPicker, cmd := m.keyPicker.Update(msg)
+		m.keyPicker = newPicker
+		return m, cmd
+	}
+
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
@@ -183,6 +271,9 @@ func (m *addFormModel) Update(msg tea.Msg) (*addFormModel, tea.Cmd) {
 			// Allow submission from any field with Ctrl+S (Save)
 			return m, m.submitForm()
 
+		case "ctrl+d":
+			return m, m.deployAndSave()
+
 		case "ctrl+j":
 			// Switch to next tab
 			m.currentTab = (m.currentTab + 1) % 2
@@ -195,7 +286,24 @@ func (m *addFormModel) Update(msg tea.Msg) (*addFormModel, tea.Cmd) {
 			m.focused = m.getFirstInputForTab(m.currentTab)
 			return m, m.updateFocus()
 
-		case "tab", "shift+tab", "enter", "up", "down":
+		case "ctrl+g":
+			if m.currentTab == tabGeneral && m.focused == identityInput {
+				m.keyCreate = NewKeyCreateForm(m.styles, m.width, m.height)
+				return m, m.keyCreate.Init()
+			}
+
+		case "ctrl+o":
+			if m.currentTab == tabGeneral && m.focused == identityInput {
+				return m, m.openKeyPicker()
+			}
+
+		case "enter":
+			if m.currentTab == tabGeneral && m.focused == identityInput {
+				return m, m.openKeyPicker()
+			}
+			return m, m.handleNavigation(msg.String())
+
+		case "tab", "shift+tab", "up", "down":
 			return m, m.handleNavigation(msg.String())
 		}
 
@@ -208,6 +316,13 @@ func (m *addFormModel) Update(msg tea.Msg) (*addFormModel, tea.Cmd) {
 			// Don't quit here, let parent handle the success
 		}
 		return m, nil
+	case addFormDeployFinishedMsg:
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		m.err = ""
+		return m, m.submitForm()
 	}
 
 	// Update inputs
@@ -236,11 +351,11 @@ func (m *addFormModel) getFirstInputForTab(tab int) int {
 func (m *addFormModel) getInputsForCurrentTab() []int {
 	switch m.currentTab {
 	case tabGeneral:
-		return []int{nameInput, hostnameInput, userInput, portInput, identityInput, proxyJumpInput, proxyCommandInput, tagsInput}
+		return addGeneralInputs[:]
 	case tabAdvanced:
-		return []int{optionsInput, remoteCommandInput, requestTTYInput}
+		return addAdvancedInputs[:]
 	default:
-		return []int{nameInput, hostnameInput, userInput, portInput, identityInput, proxyJumpInput, proxyCommandInput, tagsInput}
+		return addGeneralInputs[:]
 	}
 }
 
@@ -261,13 +376,9 @@ func (m *addFormModel) updateFocus() tea.Cmd {
 func (m *addFormModel) handleNavigation(key string) tea.Cmd {
 	currentTabInputs := m.getInputsForCurrentTab()
 
-	// Find current position within the tab
-	currentPos := 0
-	for i, input := range currentTabInputs {
-		if input == m.focused {
-			currentPos = i
-			break
-		}
+	currentPos := slices.Index(currentTabInputs, m.focused)
+	if currentPos < 0 {
+		currentPos = 0
 	}
 
 	// Handle form submission on last field of Advanced tab
@@ -316,9 +427,19 @@ func (m *addFormModel) View() string {
 		return ""
 	}
 
-	// Check if terminal height is sufficient
-	if !m.isHeightSufficient() {
+	if m.keyCreate != nil {
+		return m.keyCreate.View()
+	}
+
+	if m.keyPicker != nil {
+		return m.keyPicker.View()
+	}
+
+	if m.height < m.getMinimumCompactHeight() {
 		return m.renderHeightWarning()
+	}
+	if !m.isHeightSufficient() {
+		return m.renderCompactView()
 	}
 
 	var b strings.Builder
@@ -346,7 +467,9 @@ func (m *addFormModel) View() string {
 	// Help text
 	b.WriteString(m.styles.FormHelp.Render("Tab/Shift+Tab: navigate • Ctrl+J/K: switch tabs"))
 	b.WriteString("\n")
-	b.WriteString(m.styles.FormHelp.Render("Enter on last field: submit • Ctrl+S: save • Ctrl+C/Esc: cancel"))
+	b.WriteString(m.styles.FormHelp.Render("Identity File: Enter/Ctrl+O choose key • Ctrl+G generate • Enter on last field: submit"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("Ctrl+S: save • Ctrl+D: deploy selected key then save • Esc: cancel"))
 	b.WriteString("\n")
 	b.WriteString(m.styles.FormHelp.Render("* Required fields"))
 
@@ -379,6 +502,10 @@ func (m *addFormModel) getMinimumHeight() int {
 	return titleLines + tabLines + fieldsLines + helpLines + errorLines + 1 // +1 minimal safety margin
 }
 
+func (m *addFormModel) getMinimumCompactHeight() int {
+	return 10
+}
+
 // isHeightSufficient checks if the current terminal height is sufficient
 func (m *addFormModel) isHeightSufficient() bool {
 	return m.height >= m.getMinimumHeight()
@@ -386,13 +513,13 @@ func (m *addFormModel) isHeightSufficient() bool {
 
 // renderHeightWarning renders a warning message when height is insufficient
 func (m *addFormModel) renderHeightWarning() string {
-	required := m.getMinimumHeight()
+	required := m.getMinimumCompactHeight()
 	current := m.height
 
 	warning := m.styles.ErrorText.Render("⚠️  Terminal height is too small!")
-	details := m.styles.FormField.Render(fmt.Sprintf("Current: %d lines, Required: %d lines", current, required))
-	instruction := m.styles.FormHelp.Render("Please resize your terminal window and try again.")
-	instruction2 := m.styles.FormHelp.Render("Press Ctrl+C to cancel or resize terminal window.")
+	details := m.styles.FormField.Render(fmt.Sprintf("Current: %d lines, Need at least: %d lines", current, required))
+	instruction := m.styles.FormHelp.Render("Compact mode is available, but this terminal is still too short.")
+	instruction2 := m.styles.FormHelp.Render("Resize the terminal or cancel with Esc/Ctrl+C.")
 
 	return warning + "\n\n" + details + "\n\n" + instruction + "\n" + instruction2
 }
@@ -416,19 +543,7 @@ func (m *addFormModel) renderTabs() string {
 func (m *addFormModel) renderGeneralTab() string {
 	var b strings.Builder
 
-	fields := []struct {
-		index int
-		label string
-	}{
-		{nameInput, "Host Name *"},
-		{hostnameInput, "Hostname/IP *"},
-		{userInput, "User"},
-		{portInput, "Port"},
-		{identityInput, "Identity File"},
-		{proxyJumpInput, "ProxyJump"},
-		{proxyCommandInput, "ProxyCommand"},
-		{tagsInput, "Tags (comma-separated)"},
-	}
+	fields := m.generalTabFields()
 
 	for _, field := range fields {
 		fieldStyle := m.styles.FormField
@@ -443,6 +558,14 @@ func (m *addFormModel) renderGeneralTab() string {
 			b.WriteString(m.styles.FormHelp.Render(`  tip: use "hidden" to hide this host from the list`))
 			b.WriteString("\n")
 		}
+		if field.index == identityInput && m.focused == identityInput {
+			b.WriteString(m.styles.FormHelp.Render("  tip: Enter/Ctrl+O choose a key • Ctrl+G generates one • keep typing for a custom path"))
+			b.WriteString("\n")
+		}
+		if field.index == hostnameInput && m.focused == hostnameInput {
+			b.WriteString(m.styles.FormHelp.Render("  tip: Ctrl+D deploys the selected key to this host and saves on success"))
+			b.WriteString("\n")
+		}
 		b.WriteString("\n")
 	}
 
@@ -453,14 +576,7 @@ func (m *addFormModel) renderGeneralTab() string {
 func (m *addFormModel) renderAdvancedTab() string {
 	var b strings.Builder
 
-	fields := []struct {
-		index int
-		label string
-	}{
-		{optionsInput, "SSH Options"},
-		{remoteCommandInput, "Remote Command"},
-		{requestTTYInput, "Request TTY"},
-	}
+	fields := m.advancedTabFields()
 
 	for _, field := range fields {
 		fieldStyle := m.styles.FormField
@@ -474,6 +590,88 @@ func (m *addFormModel) renderAdvancedTab() string {
 	}
 
 	return b.String()
+}
+
+func (m *addFormModel) renderCompactView() string {
+	var b strings.Builder
+
+	b.WriteString(m.styles.FormTitle.Render("Add SSH Host Configuration"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("Compact mode"))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderTabs())
+	b.WriteString("\n\n")
+
+	fields := m.fieldsForCurrentTab()
+	currentField, currentPos := m.currentField(fields)
+
+	b.WriteString(m.styles.FormHelp.Render(fmt.Sprintf("Field %d/%d", currentPos+1, len(fields))))
+	b.WriteString("\n")
+	fieldStyle := m.styles.FocusedLabel
+	b.WriteString(fieldStyle.Render(currentField.label))
+	b.WriteString("\n")
+	b.WriteString(m.inputs[currentField.index].View())
+	b.WriteString("\n")
+
+	if currentField.index == tagsInput {
+		b.WriteString(m.styles.FormHelp.Render(`tip: use "hidden" to hide this host from the list`))
+		b.WriteString("\n")
+	}
+	if currentField.index == identityInput {
+		b.WriteString(m.styles.FormHelp.Render("tip: Enter/Ctrl+O choose • Ctrl+G generate • type manually for a custom path"))
+		b.WriteString("\n")
+	}
+	if currentField.index == hostnameInput {
+		b.WriteString(m.styles.FormHelp.Render("tip: Ctrl+D deploys the selected key and saves only if deploy succeeds"))
+		b.WriteString("\n")
+	}
+
+	if m.err != "" {
+		b.WriteString("\n")
+		b.WriteString(m.styles.ErrorText.Render("Error: " + m.err))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("↑/↓ or Tab move • Ctrl+S save • Ctrl+D deploy+save • Ctrl+J/K tabs • Enter submit on last field • Esc cancel"))
+	return b.String()
+}
+
+func (m *addFormModel) generalTabFields() []addFormField {
+	return []addFormField{
+		{nameInput, "Host Name *"},
+		{hostnameInput, "Hostname/IP *"},
+		{userInput, "User"},
+		{portInput, "Port"},
+		{identityInput, "Identity File"},
+		{proxyJumpInput, "ProxyJump"},
+		{proxyCommandInput, "ProxyCommand"},
+		{tagsInput, "Tags (comma-separated)"},
+	}
+}
+
+func (m *addFormModel) advancedTabFields() []addFormField {
+	return []addFormField{
+		{optionsInput, "SSH Options"},
+		{remoteCommandInput, "Remote Command"},
+		{requestTTYInput, "Request TTY"},
+	}
+}
+
+func (m *addFormModel) fieldsForCurrentTab() []addFormField {
+	if m.currentTab == tabAdvanced {
+		return m.advancedTabFields()
+	}
+	return m.generalTabFields()
+}
+
+func (m *addFormModel) currentField(fields []addFormField) (addFormField, int) {
+	for i, field := range fields {
+		if field.index == m.focused {
+			return field, i
+		}
+	}
+	return fields[0], 0
 }
 
 // Standalone wrapper for add form
@@ -539,16 +737,7 @@ func (m *addFormModel) submitForm() tea.Cmd {
 			return addFormSubmitMsg{err: err}
 		}
 
-		tagsStr := strings.TrimSpace(m.inputs[tagsInput].Value())
-		var tags []string
-		if tagsStr != "" {
-			for _, tag := range strings.Split(tagsStr, ",") {
-				tag = strings.TrimSpace(tag)
-				if tag != "" {
-					tags = append(tags, tag)
-				}
-			}
-		}
+		tags := parseCommaList(m.inputs[tagsInput].Value())
 
 		// Create host configuration
 		host := config.SSHHost{
@@ -574,4 +763,76 @@ func (m *addFormModel) submitForm() tea.Cmd {
 		}
 		return addFormSubmitMsg{hostname: name, err: err}
 	}
+}
+
+func (m *addFormModel) deployAndSave() tea.Cmd {
+	target := strings.TrimSpace(m.inputs[hostnameInput].Value())
+	if target == "" {
+		m.err = "hostname/IP is required before deploy"
+		return nil
+	}
+	if !validation.ValidateHostname(target) && !validation.ValidateIP(target) {
+		m.err = "invalid hostname or IP address format"
+		return nil
+	}
+
+	port := strings.TrimSpace(m.inputs[portInput].Value())
+	if port == "" {
+		port = "22"
+	}
+	if !validation.ValidatePort(port) {
+		m.err = "port must be between 1 and 65535"
+		return nil
+	}
+
+	identity := strings.TrimSpace(m.inputs[identityInput].Value())
+	if identity == "" {
+		m.err = "choose or generate a key before deploy"
+		return nil
+	}
+
+	user := strings.TrimSpace(m.inputs[userInput].Value())
+	if user == "" {
+		user = strings.TrimSpace(m.inputs[userInput].Placeholder)
+	}
+
+	m.err = ""
+	return runAddFormDeploy(keypkg.DeployOptions{
+		Target:       target,
+		User:         user,
+		Port:         port,
+		ProxyJump:    strings.TrimSpace(m.inputs[proxyJumpInput].Value()),
+		ProxyCommand: strings.TrimSpace(m.inputs[proxyCommandInput].Value()),
+		Identity:     identity,
+	})
+}
+
+func (m *addFormModel) openKeyPicker() tea.Cmd {
+	contextLine := "For new host"
+	name := strings.TrimSpace(m.inputs[nameInput].Value())
+	if name != "" {
+		contextLine = fmt.Sprintf("For %s", name)
+	}
+
+	picker, err := NewKeyPicker("Add Host", contextLine, m.styles, m.width, m.height, m.configFile)
+	if err != nil {
+		m.err = err.Error()
+		return nil
+	}
+
+	m.err = ""
+	m.keyPicker = picker
+	return m.keyPicker.Init()
+}
+
+func parseCommaList(value string) []string {
+	parts := strings.Split(value, ",")
+	items := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			items = append(items, part)
+		}
+	}
+	return items
 }

--- a/internal/ui/deploy_ui.go
+++ b/internal/ui/deploy_ui.go
@@ -1,0 +1,19 @@
+package ui
+
+import (
+	"os/exec"
+
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func runUIDeployCommand(opts keypkg.DeployOptions, onDone func(error) tea.Msg) tea.Cmd {
+	plan, err := keypkg.BuildDeployPlan(opts)
+	if err != nil {
+		return func() tea.Msg { return onDone(err) }
+	}
+
+	cmd := exec.Command(plan.Command, plan.Args...)
+	return tea.ExecProcess(cmd, onDone)
+}

--- a/internal/ui/edit_form.go
+++ b/internal/ui/edit_form.go
@@ -2,9 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Gu1llaum-3/sshm/internal/config"
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
 	"github.com/Gu1llaum-3/sshm/internal/validation"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -19,6 +21,10 @@ const (
 type editFormSubmitMsg struct {
 	hostname string
 	err      error
+}
+
+type editFormDeployFinishedMsg struct {
+	err error
 }
 
 type editFormCancelMsg struct{}
@@ -38,6 +44,19 @@ type editFormModel struct {
 	actualConfigFile string          // Actual config file to use (either configFile or host.SourceFile)
 	width            int
 	height           int
+	keyPicker        *keyPickerModel
+	keyCreate        *keyCreateFormModel
+}
+
+type editFormField struct {
+	index int
+	label string
+}
+
+var runEditFormDeploy = func(opts keypkg.DeployOptions) tea.Cmd {
+	return runUIDeployCommand(opts, func(err error) tea.Msg {
+		return editFormDeployFinishedMsg{err: err}
+	})
 }
 
 // NewEditForm creates a new edit form model that supports both single and multi-host editing
@@ -302,13 +321,9 @@ func (m *editFormModel) handleEditNavigation(key string) tea.Cmd {
 		// Navigate in properties area within current tab
 		currentTabProperties := m.getPropertiesForCurrentTab()
 
-		// Find current position within the tab
-		currentPos := 0
-		for i, prop := range currentTabProperties {
-			if prop == m.focused {
-				currentPos = i
-				break
-			}
+		currentPos := slices.Index(currentTabProperties, m.focused)
+		if currentPos < 0 {
+			currentPos = 0
 		}
 
 		// Handle form submission on last field of Advanced tab
@@ -389,6 +404,10 @@ func (m *editFormModel) getMinimumHeight() int {
 	return titleLines + configLines + hostSectionLines + hostLines + propertiesSectionLines + tabLines + fieldsLines + helpLines + errorLines + 1 // +1 minimal safety margin
 }
 
+func (m *editFormModel) getMinimumCompactHeight() int {
+	return 10
+}
+
 // isHeightSufficient checks if the current terminal height is sufficient
 func (m *editFormModel) isHeightSufficient() bool {
 	return m.height >= m.getMinimumHeight()
@@ -396,18 +415,86 @@ func (m *editFormModel) isHeightSufficient() bool {
 
 // renderHeightWarning renders a warning message when height is insufficient
 func (m *editFormModel) renderHeightWarning() string {
-	required := m.getMinimumHeight()
+	required := m.getMinimumCompactHeight()
 	current := m.height
 
 	warning := m.styles.ErrorText.Render("⚠️  Terminal height is too small!")
-	details := m.styles.FormField.Render(fmt.Sprintf("Current: %d lines, Required: %d lines", current, required))
-	instruction := m.styles.FormHelp.Render("Please resize your terminal window and try again.")
-	instruction2 := m.styles.FormHelp.Render("Press Ctrl+C to cancel or resize terminal window.")
+	details := m.styles.FormField.Render(fmt.Sprintf("Current: %d lines, Need at least: %d lines", current, required))
+	instruction := m.styles.FormHelp.Render("Compact mode is available, but this terminal is still too short.")
+	instruction2 := m.styles.FormHelp.Render("Resize the terminal or cancel with Esc/Ctrl+C.")
 
 	return warning + "\n\n" + details + "\n\n" + instruction + "\n" + instruction2
 }
 
 func (m *editFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.keyCreate != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.keyCreate.width = m.width
+			m.keyCreate.height = m.height
+			m.keyCreate.styles = m.styles
+			return m, nil
+		case keyCreateFinishedMsg:
+			if msg.err != nil {
+				m.keyCreate.err = msg.err.Error()
+				return m, nil
+			}
+			m.keyCreate = nil
+			m.inputs[3].SetValue(msg.path)
+			m.focusArea = focusAreaProperties
+			m.currentTab = 0
+			m.focused = 3
+			return m, m.updateFocus()
+		case keyCreateCancelMsg:
+			m.keyCreate = nil
+			m.focusArea = focusAreaProperties
+			m.currentTab = 0
+			m.focused = 3
+			return m, m.updateFocus()
+		}
+
+		newForm, cmd := m.keyCreate.Update(msg)
+		m.keyCreate = newForm
+		return m, cmd
+	}
+
+	if m.keyPicker != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.keyPicker.width = m.width
+			m.keyPicker.height = m.height
+			m.keyPicker.styles = m.styles
+			return m, nil
+		case keyPickerSelectMsg:
+			m.keyPicker = nil
+			m.inputs[3].SetValue(msg.path)
+			m.focusArea = focusAreaProperties
+			m.currentTab = 0
+			m.focused = 3
+			return m, m.updateFocus()
+		case keyPickerCancelMsg:
+			m.keyPicker = nil
+			m.focusArea = focusAreaProperties
+			m.currentTab = 0
+			m.focused = 3
+			return m, m.updateFocus()
+		case keyPickerCreateMsg:
+			m.keyPicker = nil
+			m.keyCreate = NewKeyCreateForm(m.styles, m.width, m.height)
+			return m, m.keyCreate.Init()
+		}
+
+		newPicker, cmd := m.keyPicker.Update(msg)
+		m.keyPicker = newPicker
+		return m, cmd
+	}
+
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
@@ -443,7 +530,24 @@ func (m *editFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.updateFocus()
 
-		case "tab", "shift+tab", "enter", "up", "down":
+		case "ctrl+g":
+			if m.focusArea == focusAreaProperties && m.currentTab == 0 && m.focused == 3 {
+				m.keyCreate = NewKeyCreateForm(m.styles, m.width, m.height)
+				return m, m.keyCreate.Init()
+			}
+
+		case "ctrl+o":
+			if m.focusArea == focusAreaProperties && m.currentTab == 0 && m.focused == 3 {
+				return m, m.openKeyPicker()
+			}
+
+		case "enter":
+			if m.focusArea == focusAreaProperties && m.currentTab == 0 && m.focused == 3 {
+				return m, m.openKeyPicker()
+			}
+			return m, m.handleEditNavigation(msg.String())
+
+		case "tab", "shift+tab", "up", "down":
 			return m, m.handleEditNavigation(msg.String())
 
 		case "ctrl+a":
@@ -455,6 +559,7 @@ func (m *editFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focusArea == focusAreaHosts && len(m.hostInputs) > 1 {
 				return m, m.deleteHostInput()
 			}
+			return m, m.deployAndSave()
 		}
 
 	case editFormSubmitMsg:
@@ -466,6 +571,13 @@ func (m *editFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// In standalone mode, the wrapper will quit
 		}
 		return m, nil
+	case editFormDeployFinishedMsg:
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		m.err = ""
+		return m, m.submitEditForm()
 	}
 
 	// Update host inputs
@@ -486,9 +598,19 @@ func (m *editFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *editFormModel) View() string {
-	// Check if terminal height is sufficient
-	if !m.isHeightSufficient() {
+	if m.keyCreate != nil {
+		return m.keyCreate.View()
+	}
+
+	if m.keyPicker != nil {
+		return m.keyPicker.View()
+	}
+
+	if m.height < m.getMinimumCompactHeight() {
 		return m.renderHeightWarning()
+	}
+	if !m.isHeightSufficient() {
+		return m.renderCompactView()
 	}
 
 	var b strings.Builder
@@ -548,10 +670,16 @@ func (m *editFormModel) View() string {
 
 	// Show different help based on number of hosts
 	if len(m.hostInputs) > 1 {
-		b.WriteString(m.styles.FormHelp.Render("Tab/↑↓/Enter: navigate • Ctrl+J/K: switch tabs • Ctrl+A: add host • Ctrl+D: delete host"))
+		b.WriteString(m.styles.FormHelp.Render("Tab/↑↓: navigate • Identity File: Enter/Ctrl+O choose key • Ctrl+G generate"))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("Ctrl+J/K: switch tabs • Ctrl+A: add host • Ctrl+D: deploy+save"))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("In Host Names: Ctrl+D deletes the focused alias"))
 		b.WriteString("\n")
 	} else {
-		b.WriteString(m.styles.FormHelp.Render("Tab/↑↓/Enter: navigate • Ctrl+J/K: switch tabs • Ctrl+A: add host"))
+		b.WriteString(m.styles.FormHelp.Render("Tab/↑↓: navigate • Identity File: Enter/Ctrl+O choose key • Ctrl+G generate"))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("Ctrl+J/K: switch tabs • Ctrl+A: add host • Ctrl+D: deploy selected key then save"))
 		b.WriteString("\n")
 	}
 	b.WriteString(m.styles.FormHelp.Render("Ctrl+S: save • Ctrl+C/Esc: cancel • * Required fields"))
@@ -578,18 +706,7 @@ func (m *editFormModel) renderEditTabs() string {
 func (m *editFormModel) renderEditGeneralTab() string {
 	var b strings.Builder
 
-	fields := []struct {
-		index int
-		label string
-	}{
-		{0, "Hostname/IP *"},
-		{1, "User"},
-		{2, "Port"},
-		{3, "Identity File"},
-		{4, "Proxy Jump"},
-		{5, "Proxy Command"},
-		{7, "Tags (comma-separated)"},
-	}
+	fields := m.generalPropertyFields()
 
 	for _, field := range fields {
 		fieldStyle := m.styles.FormField
@@ -604,6 +721,14 @@ func (m *editFormModel) renderEditGeneralTab() string {
 			b.WriteString(m.styles.FormHelp.Render(`  tip: use "hidden" to hide this host from the list`))
 			b.WriteString("\n")
 		}
+		if field.index == 3 && m.focusArea == focusAreaProperties && m.focused == 3 {
+			b.WriteString(m.styles.FormHelp.Render("  tip: Enter/Ctrl+O choose a key • Ctrl+G generates one • keep typing for a custom path"))
+			b.WriteString("\n")
+		}
+		if field.index == 0 && m.focusArea == focusAreaProperties && m.focused == 0 {
+			b.WriteString(m.styles.FormHelp.Render("  tip: Ctrl+D deploys the selected key to this host and saves on success"))
+			b.WriteString("\n")
+		}
 		b.WriteString("\n")
 	}
 
@@ -614,14 +739,7 @@ func (m *editFormModel) renderEditGeneralTab() string {
 func (m *editFormModel) renderEditAdvancedTab() string {
 	var b strings.Builder
 
-	fields := []struct {
-		index int
-		label string
-	}{
-		{6, "SSH Options"},
-		{8, "Remote Command"},
-		{9, "Request TTY"},
-	}
+	fields := m.advancedPropertyFields()
 
 	for _, field := range fields {
 		fieldStyle := m.styles.FormField
@@ -635,6 +753,106 @@ func (m *editFormModel) renderEditAdvancedTab() string {
 	}
 
 	return b.String()
+}
+
+func (m *editFormModel) renderCompactView() string {
+	var b strings.Builder
+
+	b.WriteString(m.styles.Header.Render("Edit SSH Host"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("Compact mode"))
+	b.WriteString("\n\n")
+
+	if m.host != nil && m.host.SourceFile != "" {
+		b.WriteString(m.styles.FormHelp.Render("Config: " + formatConfigFile(m.host.SourceFile)))
+		b.WriteString("\n\n")
+	}
+
+	if m.focusArea == focusAreaHosts {
+		if len(m.hostInputs) == 0 {
+			b.WriteString(m.styles.ErrorText.Render("No host names available."))
+		} else {
+			b.WriteString(m.styles.FormHelp.Render(fmt.Sprintf("Host name %d/%d", m.focused+1, len(m.hostInputs))))
+			b.WriteString("\n")
+			b.WriteString(m.styles.FocusedLabel.Render(fmt.Sprintf("Host Name %d *", m.focused+1)))
+			b.WriteString("\n")
+			b.WriteString(m.hostInputs[m.focused].View())
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString(m.renderEditTabs())
+		b.WriteString("\n\n")
+		fields := m.fieldsForCurrentPropertyTab()
+		currentField, currentPos := m.currentPropertyField(fields)
+		b.WriteString(m.styles.FormHelp.Render(fmt.Sprintf("Property %d/%d", currentPos+1, len(fields))))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FocusedLabel.Render(currentField.label))
+		b.WriteString("\n")
+		b.WriteString(m.inputs[currentField.index].View())
+		b.WriteString("\n")
+		if currentField.index == 7 {
+			b.WriteString(m.styles.FormHelp.Render(`tip: use "hidden" to hide this host from the list`))
+			b.WriteString("\n")
+		}
+		if currentField.index == 3 {
+			b.WriteString(m.styles.FormHelp.Render("tip: Enter/Ctrl+O choose • Ctrl+G generate • type manually for a custom path"))
+			b.WriteString("\n")
+		}
+		if currentField.index == 0 {
+			b.WriteString(m.styles.FormHelp.Render("tip: Ctrl+D deploys the selected key and saves only if deploy succeeds"))
+			b.WriteString("\n")
+		}
+	}
+
+	if m.err != "" {
+		b.WriteString("\n")
+		b.WriteString(m.styles.ErrorText.Render("Error: " + m.err))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	if len(m.hostInputs) > 1 && m.focusArea == focusAreaHosts {
+		b.WriteString(m.styles.FormHelp.Render("↑/↓ or Tab move • Ctrl+A add host • Ctrl+D delete alias • Ctrl+S save • Esc cancel"))
+	} else {
+		b.WriteString(m.styles.FormHelp.Render("↑/↓ or Tab move • Ctrl+J/K tabs • Ctrl+A add host • Ctrl+D deploy+save • Ctrl+S save • Esc cancel"))
+	}
+	return b.String()
+}
+
+func (m *editFormModel) generalPropertyFields() []editFormField {
+	return []editFormField{
+		{0, "Hostname/IP *"},
+		{1, "User"},
+		{2, "Port"},
+		{3, "Identity File"},
+		{4, "Proxy Jump"},
+		{5, "Proxy Command"},
+		{7, "Tags (comma-separated)"},
+	}
+}
+
+func (m *editFormModel) advancedPropertyFields() []editFormField {
+	return []editFormField{
+		{6, "SSH Options"},
+		{8, "Remote Command"},
+		{9, "Request TTY"},
+	}
+}
+
+func (m *editFormModel) fieldsForCurrentPropertyTab() []editFormField {
+	if m.currentTab == 1 {
+		return m.advancedPropertyFields()
+	}
+	return m.generalPropertyFields()
+}
+
+func (m *editFormModel) currentPropertyField(fields []editFormField) (editFormField, int) {
+	for i, field := range fields {
+		if field.index == m.focused {
+			return field, i
+		}
+	}
+	return fields[0], 0
 }
 
 // Standalone wrapper for edit form
@@ -718,17 +936,7 @@ func (m *editFormModel) submitEditForm() tea.Cmd {
 			}
 		}
 
-		// Parse tags
-		tagsStr := strings.TrimSpace(m.inputs[7].Value()) // tagsInput
-		var tags []string
-		if tagsStr != "" {
-			for _, tag := range strings.Split(tagsStr, ",") {
-				tag = strings.TrimSpace(tag)
-				if tag != "" {
-					tags = append(tags, tag)
-				}
-			}
-		}
+		tags := parseCommaList(m.inputs[7].Value()) // tagsInput
 
 		// Create the common host configuration
 		commonHost := config.SSHHost{
@@ -760,4 +968,76 @@ func (m *editFormModel) submitEditForm() tea.Cmd {
 
 		return editFormSubmitMsg{hostname: hostNames[0], err: err}
 	}
+}
+
+func (m *editFormModel) deployAndSave() tea.Cmd {
+	hostname := strings.TrimSpace(m.inputs[0].Value())
+	if hostname == "" {
+		m.err = "hostname/IP is required before deploy"
+		return nil
+	}
+	if !validation.ValidateHostname(hostname) && !validation.ValidateIP(hostname) {
+		m.err = "invalid hostname or IP address format"
+		return nil
+	}
+
+	port := strings.TrimSpace(m.inputs[2].Value())
+	if port == "" {
+		port = "22"
+	}
+	if !validation.ValidatePort(port) {
+		m.err = "port must be between 1 and 65535"
+		return nil
+	}
+
+	identity := strings.TrimSpace(m.inputs[3].Value())
+	if identity == "" {
+		m.err = "choose or generate a key before deploy"
+		return nil
+	}
+
+	user := strings.TrimSpace(m.inputs[1].Value())
+	if user == "" {
+		user = strings.TrimSpace(m.inputs[1].Placeholder)
+	}
+
+	m.err = ""
+	return runEditFormDeploy(keypkg.DeployOptions{
+		Target:       hostname,
+		User:         user,
+		Port:         port,
+		ProxyJump:    strings.TrimSpace(m.inputs[4].Value()),
+		ProxyCommand: strings.TrimSpace(m.inputs[5].Value()),
+		Identity:     identity,
+	})
+}
+
+func (m *editFormModel) openKeyPicker() tea.Cmd {
+	contextLine := "Choose key"
+	if len(m.hostInputs) > 0 {
+		var names []string
+		for _, input := range m.hostInputs {
+			name := strings.TrimSpace(input.Value())
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+		if len(names) > 0 {
+			if len(names) == 1 {
+				contextLine = fmt.Sprintf("For %s", names[0])
+			} else {
+				contextLine = fmt.Sprintf("For %s (+%d)", names[0], len(names)-1)
+			}
+		}
+	}
+
+	picker, err := NewKeyPicker("Edit Host", contextLine, m.styles, m.width, m.height, m.configFile)
+	if err != nil {
+		m.err = err.Error()
+		return nil
+	}
+
+	m.err = ""
+	m.keyPicker = picker
+	return m.keyPicker.Init()
 }

--- a/internal/ui/help_form.go
+++ b/internal/ui/help_form.go
@@ -73,6 +73,9 @@ func (m *helpModel) View() string {
 		lipgloss.JoinHorizontal(lipgloss.Left,
 			m.styles.FocusedLabel.Render("d  "),
 			m.styles.HelpText.Render("delete selected host")),
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			m.styles.FocusedLabel.Render("K  "),
+			m.styles.HelpText.Render("open keys manager")),
 	)
 
 	rightColumn := lipgloss.JoinVertical(lipgloss.Left,

--- a/internal/ui/key_attach_picker.go
+++ b/internal/ui/key_attach_picker.go
@@ -1,0 +1,294 @@
+package ui
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type keyAttachHostPickerModel struct {
+	hosts       []config.SSHHost
+	selected    int
+	styles      Styles
+	width       int
+	height      int
+	loading     bool
+	err         string
+	configFile  string
+	title       string
+	description string
+	actionLabel string
+}
+
+type keyAttachHostsLoadedMsg struct {
+	hosts []config.SSHHost
+	err   error
+}
+
+type keyAttachHostSelectMsg struct {
+	host config.SSHHost
+}
+
+type keyAttachHostCancelMsg struct{}
+
+type keyAttachFinishedMsg struct {
+	hostName string
+	path     string
+	err      error
+}
+
+type keyDeployFinishedMsg struct {
+	hostName string
+	path     string
+	err      error
+}
+
+var loadAttachHostsForUI = func(configFile string) ([]config.SSHHost, error) {
+	var (
+		hosts []config.SSHHost
+		err   error
+	)
+
+	if configFile == "" {
+		hosts, err = config.ParseSSHConfig()
+	} else {
+		hosts, err = config.ParseSSHConfigFile(configFile)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(hosts, func(a, b config.SSHHost) int {
+		if diff := cmp.Compare(a.Name, b.Name); diff != 0 {
+			return diff
+		}
+		if diff := cmp.Compare(a.SourceFile, b.SourceFile); diff != 0 {
+			return diff
+		}
+		return cmp.Compare(a.LineNumber, b.LineNumber)
+	})
+
+	return hosts, nil
+}
+
+var runAttachKeyForUI = func(host config.SSHHost, path string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := keypkg.AttachToConcreteHost(host, path, false)
+		return keyAttachFinishedMsg{
+			hostName: host.Name,
+			path:     path,
+			err:      err,
+		}
+	}
+}
+
+var runDeployKeyForUI = func(host config.SSHHost, path string, configFile string) tea.Cmd {
+	target := strings.TrimSpace(host.Hostname)
+	if target == "" {
+		target = host.Name
+	}
+
+	return runUIDeployCommand(keypkg.DeployOptions{
+		Target:       target,
+		User:         strings.TrimSpace(host.User),
+		Port:         strings.TrimSpace(host.Port),
+		ProxyJump:    strings.TrimSpace(host.ProxyJump),
+		ProxyCommand: strings.TrimSpace(host.ProxyCommand),
+		Identity:     path,
+		ConfigPath:   configFile,
+	}, func(err error) tea.Msg {
+		return keyDeployFinishedMsg{
+			hostName: host.Name,
+			path:     path,
+			err:      err,
+		}
+	})
+}
+
+func newKeyAttachHostPicker(styles Styles, width, height int, configFile string) *keyAttachHostPickerModel {
+	return &keyAttachHostPickerModel{
+		styles:      styles,
+		width:       width,
+		height:      height,
+		loading:     true,
+		configFile:  configFile,
+		title:       "SSHM - Attach Key",
+		description: "Choose a host to attach this key to.",
+		actionLabel: "attach",
+	}
+}
+
+func newKeyDeployHostPicker(styles Styles, width, height int, configFile string) *keyAttachHostPickerModel {
+	return &keyAttachHostPickerModel{
+		styles:      styles,
+		width:       width,
+		height:      height,
+		loading:     true,
+		configFile:  configFile,
+		title:       "SSHM - Deploy Key",
+		description: "Choose a host to copy this public key to.",
+		actionLabel: "deploy",
+	}
+}
+
+func (m *keyAttachHostPickerModel) Init() tea.Cmd {
+	return loadAttachHostsCmd(m.configFile)
+}
+
+func (m *keyAttachHostPickerModel) Update(msg tea.Msg) (*keyAttachHostPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.styles = NewStyles(m.width)
+		return m, nil
+	case keyAttachHostsLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			m.hosts = nil
+			m.selected = 0
+			return m, nil
+		}
+		m.err = ""
+		m.hosts = msg.hosts
+		if len(m.hosts) == 0 {
+			m.selected = 0
+			return m, nil
+		}
+		if m.selected >= len(m.hosts) {
+			m.selected = len(m.hosts) - 1
+		}
+		if m.selected < 0 {
+			m.selected = 0
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q", "left":
+			return m, func() tea.Msg { return keyAttachHostCancelMsg{} }
+		case "up", "k":
+			if !m.loading && m.selected > 0 {
+				m.selected--
+			}
+			return m, nil
+		case "down", "j":
+			if !m.loading && m.selected < len(m.hosts)-1 {
+				m.selected++
+			}
+			return m, nil
+		case "r":
+			m.loading = true
+			m.err = ""
+			return m, loadAttachHostsCmd(m.configFile)
+		case "enter":
+			if m.loading || len(m.hosts) == 0 {
+				return m, nil
+			}
+			return m, func() tea.Msg { return keyAttachHostSelectMsg{host: m.hosts[m.selected]} }
+		}
+	}
+	return m, nil
+}
+
+func (m *keyAttachHostPickerModel) View() string {
+	var b strings.Builder
+	modalWidth := clampModalWidth(m.width, 92)
+	const listIndent = "  "
+
+	b.WriteString(m.styles.Header.Render(listIndent + m.title))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + m.description))
+	b.WriteString("\n\n")
+
+	if m.err != "" {
+		b.WriteString(m.styles.ErrorText.Render("Error: " + m.err))
+		b.WriteString("\n\n")
+	}
+
+	if m.loading {
+		b.WriteString(m.styles.FormField.Render("Loading SSH hosts..."))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("Scanning SSH config."))
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FormHelp.Render("esc/← back"))
+		return renderKeyPickerModal(m.width, m.height, m.styles, "Key details", b.String(), modalWidth)
+	}
+
+	if len(m.hosts) == 0 {
+		b.WriteString(m.styles.FormField.Render("No SSH hosts found."))
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FormHelp.Render("r refresh • esc/← back"))
+		return renderKeyPickerModal(m.width, m.height, m.styles, "Key details", b.String(), modalWidth)
+	}
+
+	nameWidth, hostWidth, fileWidth := attachHostColumnWidths(m.hosts, modalWidth)
+	header := fmt.Sprintf("%s%-*s  %-*s  %-*s",
+		listIndent,
+		nameWidth, "Host",
+		hostWidth, "Hostname",
+		fileWidth, "Config",
+	)
+	b.WriteString(m.styles.FocusedLabel.Render(header))
+	b.WriteString("\n\n")
+
+	for i, host := range m.hosts {
+		row := fmt.Sprintf("%-*s  %-*s  %-*s",
+			nameWidth, truncateText(host.Name, nameWidth),
+			hostWidth, truncateText(emptyFallback(host.Hostname, "-"), hostWidth),
+			fileWidth, truncateText(formatConfigFile(host.SourceFile), fileWidth),
+		)
+		if i == m.selected {
+			b.WriteString(m.styles.Selected.Render("> " + row))
+		} else {
+			b.WriteString(listIndent + row)
+		}
+		b.WriteString("\n")
+	}
+
+	selected := m.hosts[m.selected]
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Host", selected.Name, modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Hostname", emptyFallback(selected.Hostname, "-"), modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Config", formatConfigFile(selected.SourceFile), modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Line", fmt.Sprintf("%d", selected.LineNumber), modalWidth)))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "j/k or ↑/↓ select • enter " + m.actionLabel + " • r refresh • esc/← back"))
+
+	return renderKeyPickerModal(m.width, m.height, m.styles, "Key details", b.String(), modalWidth)
+}
+
+func loadAttachHostsCmd(configFile string) tea.Cmd {
+	return func() tea.Msg {
+		hosts, err := loadAttachHostsForUI(configFile)
+		return keyAttachHostsLoadedMsg{hosts: hosts, err: err}
+	}
+}
+
+func attachHostColumnWidths(hosts []config.SSHHost, modalWidth int) (name int, hostname int, file int) {
+	name = len("Host")
+	hostname = len("Hostname")
+	file = len("Config")
+
+	for _, host := range hosts {
+		name = max(name, len(host.Name))
+		hostname = max(hostname, len(emptyFallback(host.Hostname, "-")))
+		file = max(file, len(formatConfigFile(host.SourceFile)))
+	}
+
+	totalPadding := 10
+	available := max(20, modalWidth-totalPadding)
+	name = min(name, max(10, available/5))
+	hostname = min(hostname, max(12, available/4))
+	file = min(file, max(14, available-name-hostname-6))
+	return name, hostname, file
+}

--- a/internal/ui/key_workflow.go
+++ b/internal/ui/key_workflow.go
@@ -1,0 +1,1612 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var loadKeyInventoryForUI = func(ctx context.Context, configFile string) ([]keypkg.InventoryItem, error) {
+	return keypkg.Inventory(ctx, keypkg.ExecRunner{}, configFile)
+}
+
+type keyPickerSelectMsg struct {
+	path string
+}
+
+type keyPickerCancelMsg struct{}
+
+type keyPickerCreateMsg struct{}
+
+type keyInventoryLoadedMsg struct {
+	items []keypkg.InventoryItem
+	err   error
+}
+
+type keyCreateFinishedMsg struct {
+	path string
+	err  error
+}
+
+type keyCreateCancelMsg struct{}
+
+type keysViewCloseMsg struct{}
+
+type keyPublicKeyLoadedMsg struct {
+	content string
+	err     error
+}
+
+type keyPublicKeyCopiedMsg struct {
+	err error
+}
+
+type keyPathCopiedMsg struct {
+	err error
+}
+
+type keyPathRevealedMsg struct {
+	path string
+	err  error
+}
+
+type keyDeleteFinishedMsg struct {
+	path string
+	err  error
+}
+
+type keyAgentAddedMsg struct {
+	path string
+	err  error
+}
+
+type keyOpenHostInfoMsg struct {
+	hostName   string
+	configFile string
+}
+
+type keyOpenHostEditMsg struct {
+	hostName   string
+	configFile string
+}
+
+type keyPickerMode int
+
+const (
+	keyPickerModeSelect keyPickerMode = iota
+	keyPickerModeBrowse
+)
+
+type keyPickerModel struct {
+	items      []keypkg.InventoryItem
+	selected   int
+	styles     Styles
+	width      int
+	height     int
+	backLabel  string
+	title      string
+	configFile string
+	err        string
+	loading    bool
+	mode       keyPickerMode
+}
+
+type keysViewModel struct {
+	browser       *keyPickerModel
+	keyCreate     *keyCreateFormModel
+	attachPicker  *keyAttachHostPickerModel
+	deployPicker  *keyAttachHostPickerModel
+	styles        Styles
+	width         int
+	height        int
+	configFile    string
+	inspect       bool
+	showPublic    bool
+	publicKey     string
+	status        string
+	statusErr     bool
+	hostRefs      bool
+	refSelected   int
+	deleteDialog  bool
+	deleteBlocked bool
+}
+
+var readPublicKeyFile = os.ReadFile
+
+var copyToClipboard = func(text string) error {
+	return copyTextToClipboard(text)
+}
+
+var revealPathInManager = func(path string) error {
+	return revealPath(path)
+}
+
+var deleteKeyFiles = func(privatePath string, publicPath string) error {
+	if err := os.Remove(privatePath); err != nil {
+		return err
+	}
+	if strings.TrimSpace(publicPath) == "" {
+		return nil
+	}
+	if err := os.Remove(publicPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func NewKeyPicker(backLabel string, title string, styles Styles, width, height int, configFile string) (*keyPickerModel, error) {
+	return &keyPickerModel{
+		styles:     styles,
+		width:      width,
+		height:     height,
+		backLabel:  backLabel,
+		title:      title,
+		configFile: configFile,
+		loading:    true,
+		mode:       keyPickerModeSelect,
+	}, nil
+}
+
+func NewKeyBrowser(backLabel string, styles Styles, width, height int, configFile string) *keyPickerModel {
+	return &keyPickerModel{
+		styles:     styles,
+		width:      width,
+		height:     height,
+		backLabel:  backLabel,
+		title:      "SSH keys and config references.",
+		configFile: configFile,
+		loading:    true,
+		mode:       keyPickerModeBrowse,
+	}
+}
+
+func NewKeysView(styles Styles, width, height int, configFile string) *keysViewModel {
+	return &keysViewModel{
+		browser:    NewKeyBrowser("Main screen", styles, width, height, configFile),
+		styles:     styles,
+		width:      width,
+		height:     height,
+		configFile: configFile,
+	}
+}
+
+func (m *keysViewModel) Init() tea.Cmd {
+	if m.browser == nil {
+		m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+	}
+	return m.browser.Init()
+}
+
+func (m *keysViewModel) Update(msg tea.Msg) (*keysViewModel, tea.Cmd) {
+	if m.keyCreate != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.keyCreate.width = m.width
+			m.keyCreate.height = m.height
+			m.keyCreate.styles = m.styles
+			return m, nil
+		case keyCreateFinishedMsg:
+			if msg.err != nil {
+				m.keyCreate.err = msg.err.Error()
+				return m, nil
+			}
+
+			m.keyCreate = nil
+			m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+			m.browser.title = fmt.Sprintf("Generated %s. SSH keys and config references.", filepath.Base(msg.path))
+			return m, m.browser.Init()
+		case keyCreateCancelMsg:
+			m.keyCreate = nil
+			if m.browser == nil {
+				m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+			}
+			return m, nil
+		}
+
+		newForm, cmd := m.keyCreate.Update(msg)
+		m.keyCreate = newForm
+		return m, cmd
+	}
+
+	if m.browser == nil {
+		m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+	}
+
+	switch msg := msg.(type) {
+	case keyAttachFinishedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			m.attachPicker = nil
+			return m, nil
+		}
+		m.status = fmt.Sprintf("Attached %s to %s.", filepath.Base(msg.path), msg.hostName)
+		m.statusErr = false
+		m.attachPicker = nil
+		return m, loadKeyInventoryCmd(m.configFile)
+	case keyDeployFinishedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			m.deployPicker = nil
+			return m, nil
+		}
+		m.status = fmt.Sprintf("Deployed %s to %s.", filepath.Base(msg.path), msg.hostName)
+		m.statusErr = false
+		m.deployPicker = nil
+		return m, nil
+	case keyPublicKeyLoadedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.publicKey = msg.content
+		m.showPublic = true
+		m.status = "Public key shown."
+		m.statusErr = false
+		return m, nil
+	case keyPublicKeyCopiedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.status = "Copied public key."
+		m.statusErr = false
+		return m, nil
+	case keyPathCopiedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.status = "Copied key path."
+		m.statusErr = false
+		return m, nil
+	case keyPathRevealedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.status = fmt.Sprintf("Revealed %s in file manager.", filepath.Base(msg.path))
+		m.statusErr = false
+		return m, nil
+	case keyDeleteFinishedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.status = fmt.Sprintf("Deleted %s.", filepath.Base(msg.path))
+		m.statusErr = false
+		m.inspect = false
+		m.showPublic = false
+		m.publicKey = ""
+		m.deleteDialog = false
+		m.deleteBlocked = false
+		m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+		return m, m.browser.Init()
+	case keyAgentAddedMsg:
+		if msg.err != nil {
+			m.status = msg.err.Error()
+			m.statusErr = true
+			return m, nil
+		}
+		m.status = fmt.Sprintf("Added %s to ssh-agent.", filepath.Base(msg.path))
+		m.statusErr = false
+		return m, nil
+	}
+
+	if m.deleteDialog {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "ctrl+c", "esc", "left", "q":
+				m.deleteDialog = false
+				m.deleteBlocked = false
+				return m, nil
+			case "enter":
+				if m.deleteBlocked {
+					m.deleteDialog = false
+					m.deleteBlocked = false
+					return m, nil
+				}
+				item := m.selectedItem()
+				if item == nil {
+					m.deleteDialog = false
+					return m, nil
+				}
+				return m, deleteKeyCmd(item.Path, item.PublicKeyPath)
+			}
+		}
+		return m, nil
+	}
+
+	if m.attachPicker != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.browser.width = m.width
+			m.browser.height = m.height
+			m.browser.styles = m.styles
+			m.attachPicker.width = m.width
+			m.attachPicker.height = m.height
+			m.attachPicker.styles = m.styles
+			return m, nil
+		case keyAttachHostSelectMsg:
+			item := m.selectedItem()
+			if item == nil {
+				m.attachPicker = nil
+				return m, nil
+			}
+			return m, runAttachKeyForUI(msg.host, item.Path)
+		case keyAttachHostCancelMsg:
+			m.attachPicker = nil
+			return m, nil
+		}
+
+		newPicker, cmd := m.attachPicker.Update(msg)
+		m.attachPicker = newPicker
+		return m, cmd
+	}
+
+	if m.deployPicker != nil {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.browser.width = m.width
+			m.browser.height = m.height
+			m.browser.styles = m.styles
+			m.deployPicker.width = m.width
+			m.deployPicker.height = m.height
+			m.deployPicker.styles = m.styles
+			return m, nil
+		case keyAttachHostSelectMsg:
+			item := m.selectedItem()
+			if item == nil {
+				m.deployPicker = nil
+				return m, nil
+			}
+			return m, runDeployKeyForUI(msg.host, item.Path, m.configFile)
+		case keyAttachHostCancelMsg:
+			m.deployPicker = nil
+			return m, nil
+		}
+
+		newPicker, cmd := m.deployPicker.Update(msg)
+		m.deployPicker = newPicker
+		return m, cmd
+	}
+
+	if m.hostRefs {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.browser.width = m.width
+			m.browser.height = m.height
+			m.browser.styles = m.styles
+			return m, nil
+		case tea.KeyMsg:
+			item := m.selectedItem()
+			if item == nil {
+				m.hostRefs = false
+				return m, nil
+			}
+
+			switch msg.String() {
+			case "ctrl+c", "esc", "q", "left":
+				m.hostRefs = false
+				return m, nil
+			case "up", "k":
+				if m.refSelected > 0 {
+					m.refSelected--
+				}
+				return m, nil
+			case "down", "j":
+				if m.refSelected < len(item.References)-1 {
+					m.refSelected++
+				}
+				return m, nil
+			case "enter":
+				if len(item.References) == 0 {
+					return m, nil
+				}
+				ref := item.References[m.refSelected]
+				return m, func() tea.Msg {
+					return keyOpenHostInfoMsg{hostName: ref.Host, configFile: ref.SourceFile}
+				}
+			case "e":
+				if len(item.References) == 0 {
+					return m, nil
+				}
+				ref := item.References[m.refSelected]
+				return m, func() tea.Msg {
+					return keyOpenHostEditMsg{hostName: ref.Host, configFile: ref.SourceFile}
+				}
+			}
+		}
+		newBrowser, cmd := m.browser.Update(msg)
+		m.browser = newBrowser
+		return m, cmd
+	}
+
+	if m.inspect {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.styles = NewStyles(m.width)
+			m.browser.width = m.width
+			m.browser.height = m.height
+			m.browser.styles = m.styles
+			return m, nil
+		case tea.KeyMsg:
+			item := m.selectedItem()
+			if item == nil {
+				m.inspect = false
+				return m, nil
+			}
+
+			switch msg.String() {
+			case "ctrl+c", "esc", "q", "left":
+				m.showPublic = false
+				m.publicKey = ""
+				m.status = ""
+				m.statusErr = false
+				m.inspect = false
+				return m, nil
+			case "h":
+				if len(item.References) == 0 {
+					m.status = "No config references for this key."
+					m.statusErr = false
+					return m, nil
+				}
+				m.hostRefs = true
+				m.refSelected = 0
+				return m, nil
+			case "p":
+				if m.showPublic {
+					m.showPublic = false
+					return m, nil
+				}
+				return m, loadPublicKeyCmd(item.PublicKeyPath)
+			case "c":
+				return m, copyPublicKeyCmd(item.PublicKeyPath)
+			case "y":
+				return m, copyPathCmd(item.Path)
+			case "o":
+				return m, revealPathCmd(item.Path)
+			case "a":
+				return m, addKeyToAgentCmd(item.Path)
+			case "t":
+				m.attachPicker = newKeyAttachHostPicker(m.styles, m.width, m.height, m.configFile)
+				return m, m.attachPicker.Init()
+			case "v":
+				m.deployPicker = newKeyDeployHostPicker(m.styles, m.width, m.height, m.configFile)
+				return m, m.deployPicker.Init()
+			case "d":
+				m.deleteDialog = true
+				m.deleteBlocked = !item.CanDelete
+				return m, nil
+			}
+		}
+		newBrowser, cmd := m.browser.Update(msg)
+		m.browser = newBrowser
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.styles = NewStyles(m.width)
+		m.browser.width = m.width
+		m.browser.height = m.height
+		m.browser.styles = m.styles
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "left", "q":
+			return m, func() tea.Msg { return keysViewCloseMsg{} }
+		case "enter":
+			if len(m.browser.items) == 0 || m.browser.loading {
+				return m, nil
+			}
+			m.inspect = true
+			m.showPublic = false
+			m.publicKey = ""
+			m.status = ""
+			m.statusErr = false
+			return m, nil
+		}
+	case keyPickerCancelMsg:
+		return m, func() tea.Msg { return keysViewCloseMsg{} }
+	case keyPickerCreateMsg:
+		m.keyCreate = NewKeyCreateForm(m.styles, m.width, m.height)
+		return m, m.keyCreate.Init()
+	}
+
+	newBrowser, cmd := m.browser.Update(msg)
+	m.browser = newBrowser
+	return m, cmd
+}
+
+func (m *keysViewModel) View() string {
+	if m.keyCreate != nil {
+		return m.keyCreate.View()
+	}
+	if m.browser == nil {
+		m.browser = NewKeyBrowser("Main screen", m.styles, m.width, m.height, m.configFile)
+	}
+	if m.deleteDialog {
+		return m.renderDeleteDialog()
+	}
+	if m.attachPicker != nil {
+		return m.attachPicker.View()
+	}
+	if m.deployPicker != nil {
+		return m.deployPicker.View()
+	}
+	if m.hostRefs {
+		return m.renderHostRefsView()
+	}
+	if m.inspect {
+		return m.renderInspectView()
+	}
+	return m.browser.View()
+}
+
+func (m *keysViewModel) selectedItem() *keypkg.InventoryItem {
+	if m.browser == nil || m.browser.loading || len(m.browser.items) == 0 {
+		return nil
+	}
+	if m.browser.selected < 0 || m.browser.selected >= len(m.browser.items) {
+		return nil
+	}
+	return &m.browser.items[m.browser.selected]
+}
+
+func (m *keysViewModel) renderInspectView() string {
+	item := m.selectedItem()
+	if item == nil {
+		return m.browser.View()
+	}
+
+	var b strings.Builder
+	modalWidth := clampModalWidth(m.width, 92)
+	const listIndent = "  "
+
+	b.WriteString(m.styles.Header.Render(listIndent + "SSHM - Keys"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "Key details"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FocusedLabel.Render(listIndent + filepath.Base(item.Path)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Path", displayPath(item.Path), modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Algorithm", emptyFallback(item.Algorithm, "-"), modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Perm", item.Permissions, modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Fingerprint", item.Fingerprint, modalWidth)))
+	b.WriteString("\n")
+	if item.PublicKeyPath != "" {
+		b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Public key", displayPath(item.PublicKeyPath), modalWidth)))
+	} else {
+		b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Public key", "missing", modalWidth)))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Config refs", summarizeDeclaredRefs(item.References), modalWidth)))
+
+	if m.showPublic {
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FocusedLabel.Render(listIndent + "Public key contents"))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render(listIndent + strings.TrimSpace(m.publicKey)))
+	}
+
+	if m.status != "" {
+		b.WriteString("\n\n")
+		if m.statusErr {
+			b.WriteString(m.styles.ErrorText.Render("Error: " + m.status))
+		} else {
+			b.WriteString(m.styles.FormHelp.Render(listIndent + m.status))
+		}
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "a add agent • p show/hide public key • c copy public key • y copy path"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "o reveal path • h config refs • t attach to host • v deploy to host"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "d delete"))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "esc/← back"))
+
+	return renderKeyPickerModal(m.width, m.height, m.styles, "Main screen", b.String(), modalWidth)
+}
+
+func (m *keysViewModel) renderHostRefsView() string {
+	item := m.selectedItem()
+	if item == nil {
+		return m.browser.View()
+	}
+
+	var b strings.Builder
+	modalWidth := clampModalWidth(m.width, 92)
+	const listIndent = "  "
+
+	b.WriteString(m.styles.Header.Render(listIndent + "SSHM - Keys"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "Config references for " + filepath.Base(item.Path)))
+	b.WriteString("\n\n")
+
+	for i, ref := range item.References {
+		row := ref.Host
+		if strings.TrimSpace(ref.SourceFile) != "" {
+			row += "  " + formatConfigFile(ref.SourceFile)
+		}
+		if i == m.refSelected {
+			b.WriteString(m.styles.Selected.Render("> " + row))
+		} else {
+			b.WriteString(listIndent + row)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(listIndent + "enter open host info • e edit host • esc/← back"))
+	return renderKeyPickerModal(m.width, m.height, m.styles, "Key details", b.String(), modalWidth)
+}
+
+func (m *keysViewModel) renderDeleteDialog() string {
+	item := m.selectedItem()
+	if item == nil {
+		return m.browser.View()
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.Header.Render("Delete key"))
+	b.WriteString("\n\n")
+
+	if m.deleteBlocked {
+		b.WriteString(m.styles.ErrorText.Render("Can't delete key"))
+		b.WriteString("\n\n")
+		if len(item.References) > 0 {
+			b.WriteString(m.styles.FormHelp.Render("This key is explicitly referenced by these SSH hosts:"))
+			for _, ref := range item.References {
+				b.WriteString("\n")
+				b.WriteString(m.styles.FormHelp.Render("  - " + ref.Host))
+			}
+		} else {
+			b.WriteString(m.styles.FormHelp.Render("Delete is blocked by the current safety rules."))
+		}
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FormHelp.Render("Enter/Esc/← back"))
+		return renderKeyModal(m.width, m.height, m.styles, b.String(), 72)
+	}
+
+	b.WriteString(m.styles.FormHelp.Render("Delete key " + displayPath(item.Path) + "?"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render("No explicit IdentityFile entries point to this key."))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("SSHM can't verify inherited or external SSH config."))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render("Private: " + displayPath(item.Path)))
+	if item.PublicKeyPath != "" {
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("Public:  " + displayPath(item.PublicKeyPath)))
+	}
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render("Enter delete • Esc/← cancel"))
+	return renderKeyModal(m.width, m.height, m.styles, b.String(), 72)
+}
+
+func (m *keyPickerModel) Init() tea.Cmd {
+	return loadKeyInventoryCmd(m.configFile)
+}
+
+func (m *keyPickerModel) Update(msg tea.Msg) (*keyPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.styles = NewStyles(m.width)
+		return m, nil
+
+	case keyInventoryLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			m.items = nil
+			m.selected = 0
+			return m, nil
+		}
+		m.err = ""
+		m.items = msg.items
+		if len(m.items) == 0 {
+			m.selected = 0
+			return m, nil
+		}
+		if m.selected >= len(m.items) {
+			m.selected = len(m.items) - 1
+		}
+		if m.selected < 0 {
+			m.selected = 0
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q", "left":
+			return m, func() tea.Msg { return keyPickerCancelMsg{} }
+		case "enter":
+			if m.loading || len(m.items) == 0 || m.mode == keyPickerModeBrowse {
+				return m, nil
+			}
+			path := m.items[m.selected].Path
+			return m, func() tea.Msg { return keyPickerSelectMsg{path: path} }
+		case "g", "ctrl+g":
+			return m, func() tea.Msg { return keyPickerCreateMsg{} }
+		case "r":
+			m.loading = true
+			m.err = ""
+			return m, loadKeyInventoryCmd(m.configFile)
+		case "up", "k":
+			if m.loading {
+				return m, nil
+			}
+			if m.selected > 0 {
+				m.selected--
+			}
+			return m, nil
+		case "down", "j":
+			if m.loading {
+				return m, nil
+			}
+			if m.selected < len(m.items)-1 {
+				m.selected++
+			}
+			return m, nil
+		}
+	}
+
+	return m, nil
+}
+
+func (m *keyPickerModel) View() string {
+	var b strings.Builder
+	modalWidth := clampModalWidth(m.width, 92)
+	const listIndent = "  "
+
+	b.WriteString(m.styles.Header.Render(listIndent + "SSHM - Keys"))
+	b.WriteString("\n\n")
+	if strings.TrimSpace(m.title) != "" {
+		b.WriteString(m.styles.FormHelp.Render(listIndent + m.title))
+		b.WriteString("\n\n")
+	}
+
+	if m.err != "" {
+		b.WriteString(m.styles.ErrorText.Render("Error: " + m.err))
+		b.WriteString("\n\n")
+	}
+
+	if m.loading {
+		b.WriteString(m.styles.FormField.Render("Loading local SSH keys..."))
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("Scanning ~/.ssh and SSH config references."))
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FormHelp.Render("g generate • esc/← back"))
+		return renderKeyPickerModal(m.width, m.height, m.styles, m.backLabel, b.String(), modalWidth)
+	}
+
+	if len(m.items) == 0 {
+		b.WriteString(m.styles.FormField.Render("No local SSH keys found."))
+		b.WriteString("\n")
+		if m.mode == keyPickerModeBrowse {
+			b.WriteString(m.styles.FormHelp.Render("Press g to generate a key. Esc or ← returns to hosts."))
+		} else {
+			b.WriteString(m.styles.FormHelp.Render("Press g to generate a key, or Esc to return and enter a path."))
+		}
+		b.WriteString("\n\n")
+		b.WriteString(m.styles.FormHelp.Render("g generate • esc/← back"))
+		return renderKeyPickerModal(m.width, m.height, m.styles, m.backLabel, b.String(), modalWidth)
+	}
+
+	nameWidth, algoWidth, permWidth, refsWidth := keyTableColumnWidths(m.items, modalWidth)
+	header := fmt.Sprintf("%s%-*s        %-*s  %-*s  %-*s",
+		listIndent,
+		nameWidth, "Name",
+		algoWidth, "Algo",
+		permWidth, "Perm",
+		refsWidth, "Config",
+	)
+	b.WriteString(m.styles.FocusedLabel.Render(header))
+	b.WriteString("\n\n")
+
+	for i, item := range m.items {
+		row := fmt.Sprintf("%-*s        %-*s  %-*s  %-*s",
+			nameWidth, truncateText(filepath.Base(item.Path), nameWidth),
+			algoWidth, emptyFallback(item.Algorithm, "-"),
+			permWidth, item.Permissions,
+			refsWidth, truncateText(summarizeDeclaredRefCount(item.References), refsWidth),
+		)
+		if i == m.selected {
+			b.WriteString(m.styles.Selected.Render("> " + row))
+		} else {
+			b.WriteString(listIndent + row)
+		}
+		b.WriteString("\n")
+		if i == m.selected {
+			b.WriteString(m.styles.FormHelp.Render(listIndent + truncateMiddle(displayPath(item.Path), modalWidth-6)))
+			b.WriteString("\n")
+		}
+	}
+
+	selected := m.items[m.selected]
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Path", displayPath(selected.Path), modalWidth)))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Fingerprint", selected.Fingerprint, modalWidth)))
+	b.WriteString("\n")
+	if selected.PublicKeyPath != "" {
+		b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Public key", displayPath(selected.PublicKeyPath), modalWidth)))
+	} else {
+		b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Public key", "missing", modalWidth)))
+	}
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render(renderKeyDetailLine("Config refs", summarizeDeclaredRefs(selected.References), modalWidth)))
+	b.WriteString("\n\n")
+	if m.mode == keyPickerModeBrowse {
+		b.WriteString(m.styles.FormHelp.Render(listIndent + "j/k or ↑/↓ select • g generate • r refresh • esc/← back"))
+	} else {
+		b.WriteString(m.styles.FormHelp.Render(listIndent + "j/k or ↑/↓ select • enter choose • g generate • r refresh • esc/← back"))
+	}
+	return renderKeyPickerModal(m.width, m.height, m.styles, m.backLabel, b.String(), modalWidth)
+}
+
+type keyCreateFormModel struct {
+	inputs           []textinput.Model
+	focused          int
+	currentTab       int
+	algorithmOptions []string
+	algorithmIndex   int
+	styles           Styles
+	width            int
+	height           int
+	err              string
+}
+
+const (
+	keyCreateNameInput = iota
+	keyCreateCommentInput
+	keyCreatePathInput
+	keyCreateAlgorithmInput
+)
+
+const (
+	keyCreateTabGeneral = iota
+	keyCreateTabAdvanced
+)
+
+var (
+	keyCreateGeneralInputs  = [...]int{keyCreateNameInput, keyCreateCommentInput, keyCreatePathInput}
+	keyCreateAdvancedInputs = [...]int{keyCreateAlgorithmInput}
+)
+
+func NewKeyCreateForm(styles Styles, width, height int) *keyCreateFormModel {
+	defaultPath, err := config.GetSSHDirectory()
+	if err != nil {
+		defaultPath = "~/.ssh"
+	}
+
+	defaultComment := suggestedKeyComment()
+	algorithms := keypkg.AllowedGenerateAlgorithms()
+	defaultAlgorithm, _ := keypkg.NormalizeGenerateAlgorithm("")
+	algorithmIndex := 0
+	for i, algorithm := range algorithms {
+		if algorithm == defaultAlgorithm {
+			algorithmIndex = i
+			break
+		}
+	}
+
+	inputs := make([]textinput.Model, 3)
+
+	inputs[keyCreateNameInput] = textinput.New()
+	inputs[keyCreateNameInput].Placeholder = "id_ed25519_label"
+	inputs[keyCreateNameInput].Focus()
+	inputs[keyCreateNameInput].CharLimit = 120
+	inputs[keyCreateNameInput].Width = 40
+
+	inputs[keyCreateCommentInput] = textinput.New()
+	inputs[keyCreateCommentInput].Placeholder = defaultComment
+	inputs[keyCreateCommentInput].CharLimit = 200
+	inputs[keyCreateCommentInput].Width = 60
+
+	inputs[keyCreatePathInput] = textinput.New()
+	inputs[keyCreatePathInput].SetValue(defaultPath)
+	inputs[keyCreatePathInput].CharLimit = 240
+	inputs[keyCreatePathInput].Width = 60
+
+	return &keyCreateFormModel{
+		inputs:           inputs,
+		focused:          keyCreateNameInput,
+		currentTab:       keyCreateTabGeneral,
+		algorithmOptions: algorithms,
+		algorithmIndex:   algorithmIndex,
+		styles:           styles,
+		width:            width,
+		height:           height,
+	}
+}
+
+func (m *keyCreateFormModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m *keyCreateFormModel) Update(msg tea.Msg) (*keyCreateFormModel, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.styles = NewStyles(m.width)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			return m, func() tea.Msg { return keyCreateCancelMsg{} }
+		case "ctrl+s":
+			return m, m.submit()
+		case "ctrl+j":
+			m.currentTab = keyCreateTabAdvanced
+			m.focused = keyCreateAlgorithmInput
+			return m, m.updateFocus()
+		case "ctrl+k":
+			m.currentTab = keyCreateTabGeneral
+			m.focused = keyCreateNameInput
+			return m, m.updateFocus()
+		case "left", "h":
+			if m.currentTab == keyCreateTabAdvanced && m.focused == keyCreateAlgorithmInput {
+				m.moveAlgorithmSelection(-1)
+				return m, nil
+			}
+		case "right", "l":
+			if m.currentTab == keyCreateTabAdvanced && m.focused == keyCreateAlgorithmInput {
+				m.moveAlgorithmSelection(1)
+				return m, nil
+			}
+		case "tab", "enter", "down", "shift+tab", "up":
+			return m, m.handleNavigation(msg.String())
+		}
+	}
+
+	if m.currentTab == keyCreateTabGeneral {
+		cmd := make([]tea.Cmd, len(m.inputs))
+		for i := range m.inputs {
+			if !m.isInputVisible(i) {
+				continue
+			}
+			m.inputs[i], cmd[i] = m.inputs[i].Update(msg)
+		}
+		cmds = append(cmds, cmd...)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *keyCreateFormModel) handleNavigation(key string) tea.Cmd {
+	switch key {
+	case "enter":
+		if m.currentTab == keyCreateTabAdvanced {
+			return m.submit()
+		}
+		return m.moveForward(true)
+	case "down", "tab":
+		return m.moveForward(false)
+	case "up", "shift+tab":
+		return m.moveBackward()
+	default:
+		return nil
+	}
+}
+
+func (m *keyCreateFormModel) isInputVisible(index int) bool {
+	return slices.Contains(m.visibleInputIndices(), index)
+}
+
+func (m *keyCreateFormModel) visibleInputIndices() []int {
+	if m.currentTab == keyCreateTabAdvanced {
+		return keyCreateAdvancedInputs[:]
+	}
+	return keyCreateGeneralInputs[:]
+}
+
+func (m *keyCreateFormModel) moveForward(submitOnLast bool) tea.Cmd {
+	if m.currentTab == keyCreateTabAdvanced {
+		if submitOnLast {
+			return m.submit()
+		}
+		return nil
+	}
+
+	inputs := keyCreateGeneralInputs[:]
+	currentPos := slices.Index(inputs, m.focused)
+	if currentPos < 0 {
+		currentPos = 0
+	}
+
+	if currentPos == len(inputs)-1 {
+		if submitOnLast {
+			return m.submit()
+		}
+		m.currentTab = keyCreateTabAdvanced
+		m.focused = keyCreateAlgorithmInput
+		return m.updateFocus()
+	}
+
+	m.focused = inputs[currentPos+1]
+	return m.updateFocus()
+}
+
+func (m *keyCreateFormModel) moveBackward() tea.Cmd {
+	if m.currentTab == keyCreateTabAdvanced {
+		m.currentTab = keyCreateTabGeneral
+		m.focused = keyCreatePathInput
+		return m.updateFocus()
+	}
+
+	inputs := keyCreateGeneralInputs[:]
+	currentPos := slices.Index(inputs, m.focused)
+	if currentPos < 0 {
+		currentPos = 0
+	}
+	if currentPos == 0 {
+		return nil
+	}
+
+	m.focused = inputs[currentPos-1]
+	return m.updateFocus()
+}
+
+func (m *keyCreateFormModel) moveAlgorithmSelection(delta int) {
+	if len(m.algorithmOptions) == 0 {
+		return
+	}
+	m.algorithmIndex += delta
+	if m.algorithmIndex < 0 {
+		m.algorithmIndex = len(m.algorithmOptions) - 1
+	}
+	if m.algorithmIndex >= len(m.algorithmOptions) {
+		m.algorithmIndex = 0
+	}
+}
+
+func (m *keyCreateFormModel) renderTabs() string {
+	var generalTab, advancedTab string
+
+	if m.currentTab == keyCreateTabGeneral {
+		generalTab = m.styles.FocusedLabel.Render("[ General ]")
+		advancedTab = m.styles.FormField.Render("  Advanced  ")
+	} else {
+		generalTab = m.styles.FormField.Render("  General  ")
+		advancedTab = m.styles.FocusedLabel.Render("[ Advanced ]")
+	}
+
+	return generalTab + "  " + advancedTab
+}
+
+func (m *keyCreateFormModel) renderFields(fields []struct {
+	index int
+	label string
+}) string {
+	var b strings.Builder
+
+	for _, field := range fields {
+		fieldStyle := m.styles.FormField
+		if m.focused == field.index {
+			fieldStyle = m.styles.FocusedLabel
+		}
+		b.WriteString(fieldStyle.Render(field.label))
+		b.WriteString("\n")
+		b.WriteString(m.inputs[field.index].View())
+		b.WriteString("\n\n")
+	}
+
+	return b.String()
+}
+
+func (m *keyCreateFormModel) renderAlgorithmPicker() string {
+	var options []string
+	for i, algorithm := range m.algorithmOptions {
+		label := strings.ToUpper(algorithm)
+		if i == m.algorithmIndex {
+			options = append(options, m.styles.Selected.Render(" "+label+" "))
+			continue
+		}
+		options = append(options, m.styles.FormField.Render(" "+label+" "))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, options...)
+}
+
+func (m *keyCreateFormModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(m.styles.Header.Render("Generate SSH key"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.FormHelp.Render("Runs local ssh-keygen. SSHM never stores private keys or passphrases."))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderTabs())
+	b.WriteString("\n\n")
+
+	if m.currentTab == keyCreateTabGeneral {
+		b.WriteString(m.renderFields([]struct {
+			index int
+			label string
+		}{
+			{keyCreateNameInput, "Key name *"},
+			{keyCreateCommentInput, "Comment"},
+			{keyCreatePathInput, "Directory"},
+		}))
+	} else {
+		fieldStyle := m.styles.FormField
+		if m.focused == keyCreateAlgorithmInput {
+			fieldStyle = m.styles.FocusedLabel
+		}
+		b.WriteString(fieldStyle.Render("Algorithm"))
+		b.WriteString("\n")
+		b.WriteString(m.renderAlgorithmPicker())
+		b.WriteString("\n")
+		b.WriteString(m.styles.FormHelp.Render("←/→ choose • ↑ General"))
+		b.WriteString("\n\n")
+	}
+
+	if m.err != "" {
+		b.WriteString(m.styles.ErrorText.Render("Error: " + m.err))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(m.styles.FormHelp.Render("Default: ed25519."))
+	b.WriteString("\n")
+	b.WriteString(m.styles.FormHelp.Render("tab move • ctrl+j/k tabs • ↓ Advanced • ↑ General • ctrl+s generate • esc back"))
+	return renderKeyModal(m.width, m.height, m.styles, b.String(), 92)
+}
+
+func (m *keyCreateFormModel) updateFocus() tea.Cmd {
+	var cmds []tea.Cmd
+	for i := range m.inputs {
+		if !m.isInputVisible(i) {
+			m.inputs[i].Blur()
+			continue
+		}
+		if i == m.focused && i != keyCreateAlgorithmInput {
+			cmds = append(cmds, m.inputs[i].Focus())
+		} else {
+			m.inputs[i].Blur()
+		}
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *keyCreateFormModel) submit() tea.Cmd {
+	name := strings.TrimSpace(m.inputs[keyCreateNameInput].Value())
+	comment := strings.TrimSpace(m.inputs[keyCreateCommentInput].Value())
+	directory := strings.TrimSpace(m.inputs[keyCreatePathInput].Value())
+	algorithm := ""
+	if len(m.algorithmOptions) > 0 && m.algorithmIndex >= 0 && m.algorithmIndex < len(m.algorithmOptions) {
+		algorithm = m.algorithmOptions[m.algorithmIndex]
+	}
+
+	if comment == "" {
+		comment = m.inputs[keyCreateCommentInput].Placeholder
+	}
+
+	algorithm, err := keypkg.NormalizeGenerateAlgorithm(algorithm)
+	if err != nil {
+		m.err = err.Error()
+		return nil
+	}
+
+	result, args, err := keypkg.BuildGenerateArgs(keypkg.GenerateOptions{
+		Name:      name,
+		Algorithm: algorithm,
+		Comment:   comment,
+		Directory: directory,
+		KDFRounds: 100,
+	})
+	if err != nil {
+		m.err = err.Error()
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(result.PrivateKeyPath), 0700); err != nil {
+		m.err = fmt.Sprintf("create key directory: %v", err)
+		return nil
+	}
+
+	m.err = ""
+
+	cmd := exec.Command("ssh-keygen", args...)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return keyCreateFinishedMsg{
+			path: result.PrivateKeyPath,
+			err:  err,
+		}
+	})
+}
+
+func suggestedKeyComment() string {
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Sprintf("user@host (%s)", time.Now().Format("2006-01-02"))
+	}
+
+	hostName, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostName) == "" {
+		hostName = "host"
+	}
+
+	return fmt.Sprintf("%s@%s (%s)", currentUser.Username, hostName, time.Now().Format("2006-01-02"))
+}
+
+func loadPublicKeyCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(path) == "" {
+			return keyPublicKeyLoadedMsg{err: fmt.Errorf("public key file is missing")}
+		}
+		content, err := readPublicKeyFile(path)
+		if err != nil {
+			return keyPublicKeyLoadedMsg{err: err}
+		}
+		return keyPublicKeyLoadedMsg{content: string(content)}
+	}
+}
+
+func copyPublicKeyCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(path) == "" {
+			return keyPublicKeyCopiedMsg{err: fmt.Errorf("public key file is missing")}
+		}
+		content, err := readPublicKeyFile(path)
+		if err != nil {
+			return keyPublicKeyCopiedMsg{err: err}
+		}
+		if err := copyToClipboard(string(content)); err != nil {
+			return keyPublicKeyCopiedMsg{err: err}
+		}
+		return keyPublicKeyCopiedMsg{}
+	}
+}
+
+func copyPathCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(path) == "" {
+			return keyPathCopiedMsg{err: fmt.Errorf("key path is missing")}
+		}
+		return keyPathCopiedMsg{err: copyToClipboard(path)}
+	}
+}
+
+func revealPathCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(path) == "" {
+			return keyPathRevealedMsg{err: fmt.Errorf("key path is missing")}
+		}
+		return keyPathRevealedMsg{
+			path: path,
+			err:  revealPathInManager(path),
+		}
+	}
+}
+
+func deleteKeyCmd(privatePath string, publicPath string) tea.Cmd {
+	return func() tea.Msg {
+		err := deleteKeyFiles(privatePath, publicPath)
+		return keyDeleteFinishedMsg{
+			path: privatePath,
+			err:  err,
+		}
+	}
+}
+
+func addKeyToAgentCmd(path string) tea.Cmd {
+	normalized, args, err := keypkg.BuildAddArgs(path)
+	if err != nil {
+		return func() tea.Msg { return keyAgentAddedMsg{err: err} }
+	}
+
+	cmd := exec.Command("ssh-add", args...)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return keyAgentAddedMsg{
+			path: normalized,
+			err:  err,
+		}
+	})
+}
+
+func summarizeDeclaredRefs(refs []keypkg.Reference) string {
+	if len(refs) == 0 {
+		return "none"
+	}
+
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.Host)
+	}
+
+	if len(names) <= 3 {
+		return strings.Join(names, ", ")
+	}
+
+	return strings.Join(names[:3], ", ") + fmt.Sprintf(" +%d more", len(names)-3)
+}
+
+func summarizeDeclaredRefCount(refs []keypkg.Reference) string {
+	switch len(refs) {
+	case 0:
+		return "none"
+	case 1:
+		return "1 host"
+	default:
+		return fmt.Sprintf("%d hosts", len(refs))
+	}
+}
+
+func emptyFallback(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func copyTextToClipboard(text string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "clip")
+	default:
+		switch {
+		case commandExists("wl-copy"):
+			cmd = exec.Command("wl-copy")
+		case commandExists("xclip"):
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		case commandExists("xsel"):
+			cmd = exec.Command("xsel", "--clipboard", "--input")
+		default:
+			return fmt.Errorf("no clipboard command available")
+		}
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			return fmt.Errorf("copy to clipboard: %w", err)
+		}
+		return fmt.Errorf("copy to clipboard: %s", message)
+	}
+	return nil
+}
+
+func commandExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func revealPath(path string) error {
+	cleanPath := filepath.Clean(path)
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", "-R", cleanPath)
+	case "windows":
+		cmd = exec.Command("explorer.exe", "/select,", cleanPath)
+	default:
+		if !commandExists("xdg-open") {
+			return fmt.Errorf("no file manager command available")
+		}
+		cmd = exec.Command("xdg-open", filepath.Dir(cleanPath))
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			return fmt.Errorf("reveal path: %w", err)
+		}
+		return fmt.Errorf("reveal path: %s", message)
+	}
+	return nil
+}
+
+func renderKeyModal(width int, height int, styles Styles, content string, maxWidth int) string {
+	container := styles.FormContainer.Width(clampModalWidth(width, maxWidth)).Render(content)
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		container,
+	)
+}
+
+func renderKeyPickerModal(width int, height int, styles Styles, backLabel string, content string, modalWidth int) string {
+	container := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(PrimaryColor)).
+		Padding(1, 1).
+		Width(modalWidth).
+		Render(content)
+
+	if strings.TrimSpace(backLabel) != "" {
+		back := lipgloss.NewStyle().
+			MarginLeft(2).
+			Render(styles.FormHelp.Render("← back to " + backLabel))
+		container = lipgloss.JoinVertical(lipgloss.Left, back, container)
+	}
+
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		container,
+	)
+}
+
+func clampModalWidth(screenWidth int, maxWidth int) int {
+	if screenWidth <= 0 {
+		return maxWidth
+	}
+
+	width := screenWidth - 6
+	if width < 48 {
+		width = 48
+	}
+	if width > maxWidth {
+		width = maxWidth
+	}
+	return width
+}
+
+func keyTableColumnWidths(items []keypkg.InventoryItem, modalWidth int) (name int, algo int, perm int, refs int) {
+	const totalColumnGaps = 12
+
+	contentWidth := modalWidth - 6
+	if contentWidth < 48 {
+		contentWidth = 48
+	}
+
+	algo = 7
+	perm = 4
+	refs = 10
+	name = 18
+	for _, item := range items {
+		width := len([]rune(filepath.Base(item.Path)))
+		if width > name {
+			name = width
+		}
+	}
+
+	nameMax := contentWidth - algo - perm - refs - totalColumnGaps
+	if nameMax < 18 {
+		nameMax = 18
+	}
+	if nameMax > 28 {
+		nameMax = 28
+	}
+	if name > nameMax {
+		name = nameMax
+	}
+	return name, algo, perm, refs
+}
+
+func renderKeyDetailLine(label string, value string, modalWidth int) string {
+	const (
+		listIndent       = "  "
+		detailLabelWidth = 13
+	)
+
+	valueWidth := modalWidth - len(listIndent) - detailLabelWidth - 3
+	if valueWidth < 12 {
+		valueWidth = 12
+	}
+
+	return fmt.Sprintf("%s%-*s %s",
+		listIndent,
+		detailLabelWidth, label,
+		truncateMiddle(value, valueWidth),
+	)
+}
+
+func truncateText(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= width {
+		return value
+	}
+	if width <= 1 {
+		return string(runes[:width])
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+func truncateMiddle(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= width {
+		return value
+	}
+	if width <= 3 {
+		return string(runes[:width])
+	}
+
+	head := (width - 1) / 2
+	tail := width - 1 - head
+	return string(runes[:head]) + "…" + string(runes[len(runes)-tail:])
+}
+
+func displayPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
+	clean := filepath.Clean(path)
+	if clean == homeDir {
+		return "~"
+	}
+	homePrefix := homeDir + string(os.PathSeparator)
+	if rest, ok := strings.CutPrefix(clean, homePrefix); ok {
+		return "~" + string(os.PathSeparator) + rest
+	}
+	return clean
+}
+
+func loadKeyInventoryCmd(configFile string) tea.Cmd {
+	return func() tea.Msg {
+		items, err := loadKeyInventoryForUI(context.Background(), configFile)
+		return keyInventoryLoadedMsg{
+			items: items,
+			err:   err,
+		}
+	}
+}

--- a/internal/ui/key_workflow_test.go
+++ b/internal/ui/key_workflow_test.go
@@ -1,0 +1,2110 @@
+package ui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
+	keypkg "github.com/Gu1llaum-3/sshm/internal/key"
+
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func stubKeyInventoryForUITest(t *testing.T, items []keypkg.InventoryItem, err error) {
+	t.Helper()
+
+	original := loadKeyInventoryForUI
+	loadKeyInventoryForUI = func(context.Context, string) ([]keypkg.InventoryItem, error) {
+		return items, err
+	}
+	t.Cleanup(func() {
+		loadKeyInventoryForUI = original
+	})
+}
+
+func stubClipboardForUITest(t *testing.T, fn func(string) error) {
+	t.Helper()
+
+	original := copyToClipboard
+	copyToClipboard = fn
+	t.Cleanup(func() {
+		copyToClipboard = original
+	})
+}
+
+func stubRevealPathForUITest(t *testing.T, fn func(string) error) {
+	t.Helper()
+
+	original := revealPathInManager
+	revealPathInManager = fn
+	t.Cleanup(func() {
+		revealPathInManager = original
+	})
+}
+
+func stubAddFormDeployForUITest(t *testing.T, fn func(keypkg.DeployOptions) tea.Cmd) {
+	t.Helper()
+
+	original := runAddFormDeploy
+	runAddFormDeploy = fn
+	t.Cleanup(func() {
+		runAddFormDeploy = original
+	})
+}
+
+func stubEditFormDeployForUITest(t *testing.T, fn func(keypkg.DeployOptions) tea.Cmd) {
+	t.Helper()
+
+	original := runEditFormDeploy
+	runEditFormDeploy = fn
+	t.Cleanup(func() {
+		runEditFormDeploy = original
+	})
+}
+
+func stubAttachHostsForUITest(t *testing.T, fn func(string) ([]config.SSHHost, error)) {
+	t.Helper()
+
+	original := loadAttachHostsForUI
+	loadAttachHostsForUI = fn
+	t.Cleanup(func() {
+		loadAttachHostsForUI = original
+	})
+}
+
+func stubAttachKeyForUITest(t *testing.T, fn func(config.SSHHost, string) tea.Cmd) {
+	t.Helper()
+
+	original := runAttachKeyForUI
+	runAttachKeyForUI = fn
+	t.Cleanup(func() {
+		runAttachKeyForUI = original
+	})
+}
+
+func stubDeployKeyForUITest(t *testing.T, fn func(config.SSHHost, string, string) tea.Cmd) {
+	t.Helper()
+
+	original := runDeployKeyForUI
+	runDeployKeyForUI = fn
+	t.Cleanup(func() {
+		runDeployKeyForUI = original
+	})
+}
+
+func TestAddFormOpensKeyPickerFromIdentityField(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	if updated.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if !updated.keyPicker.loading {
+		t.Fatalf("loading = false, want async picker load")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+}
+
+func TestAddFormOpensKeyPickerWithEnterFromIdentityField(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if updated.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open from Enter")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+}
+
+func TestAddFormSelectKeyAppliesIdentityPath(t *testing.T) {
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.keyPicker = &keyPickerModel{}
+
+	updated, cmd := form.Update(keyPickerSelectMsg{path: "/tmp/id_ed25519_selected"})
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after selection")
+	}
+	if got := updated.inputs[identityInput].Value(); got != "/tmp/id_ed25519_selected" {
+		t.Fatalf("identity value = %q", got)
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want focus update command")
+	}
+}
+
+func TestAddFormFullPickerSelectionFlow(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	form = openLoadedAddPicker(t, form)
+
+	form, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want selection command")
+	}
+
+	msg := cmd()
+	form, _ = form.Update(msg)
+	if got := form.inputs[identityInput].Value(); got != "/tmp/id_ed25519_demo" {
+		t.Fatalf("identity value = %q", got)
+	}
+	if form.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after full selection flow")
+	}
+}
+
+func TestAddFormTransitionsFromPickerToCreateAndBack(t *testing.T) {
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.keyPicker = &keyPickerModel{}
+
+	updated, cmd := form.Update(keyPickerCreateMsg{})
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after opening create flow")
+	}
+	if updated.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want blink command when create form opens")
+	}
+
+	updated, cmd = updated.Update(keyCreateFinishedMsg{path: "/tmp/id_ed25519_new"})
+	if updated.keyCreate != nil {
+		t.Fatalf("keyCreate != nil after completion")
+	}
+	if got := updated.inputs[identityInput].Value(); got != "/tmp/id_ed25519_new" {
+		t.Fatalf("identity value = %q", got)
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want focus update command after completion")
+	}
+}
+
+func TestAddFormPickerGOpensCreateFlow(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	form = openLoadedAddPicker(t, form)
+
+	form, cmd := form.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g")})
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want create command")
+	}
+
+	msg := cmd()
+	form, _ = form.Update(msg)
+	if form.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form to open")
+	}
+	if form.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after opening create flow")
+	}
+}
+
+func TestAddFormPickerEscReturnsToForm(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	form = openLoadedAddPicker(t, form)
+
+	form, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel command")
+	}
+
+	msg := cmd()
+	form, _ = form.Update(msg)
+	if form.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after cancel")
+	}
+	if form.focused != identityInput {
+		t.Fatalf("focused = %d, want identityInput", form.focused)
+	}
+}
+
+func TestAddFormPickerLeftReturnsToForm(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	form = openLoadedAddPicker(t, form)
+
+	form, cmd := form.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel command")
+	}
+
+	msg := cmd()
+	form, _ = form.Update(msg)
+	if form.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after cancel")
+	}
+	if form.focused != identityInput {
+		t.Fatalf("focused = %d, want identityInput", form.focused)
+	}
+}
+
+func TestAddFormOpensKeyCreateDirectlyFromIdentityField(t *testing.T) {
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.focused = identityInput
+	form.currentTab = tabGeneral
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	if updated.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want blink command when create form opens")
+	}
+}
+
+func TestAddFormCtrlDDeploysAndThenSavesHost(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	keyDir := t.TempDir()
+	privateKey := keyDir + "/id_ed25519_demo"
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	var gotOpts keypkg.DeployOptions
+	stubAddFormDeployForUITest(t, func(opts keypkg.DeployOptions) tea.Cmd {
+		gotOpts = opts
+		return func() tea.Msg { return addFormDeployFinishedMsg{} }
+	})
+
+	form := NewAddForm("", NewStyles(80), 80, 24, configFile)
+	form.inputs[nameInput].SetValue("demo")
+	form.inputs[hostnameInput].SetValue("203.0.113.10")
+	form.inputs[userInput].SetValue("root")
+	form.inputs[portInput].SetValue("2222")
+	form.inputs[identityInput].SetValue(privateKey)
+	form.inputs[proxyJumpInput].SetValue("bastion")
+	form.inputs[proxyCommandInput].SetValue("ssh -W %h:%p jump-host")
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want deploy command")
+	}
+	if gotOpts.Target != "203.0.113.10" || gotOpts.User != "root" || gotOpts.Port != "2222" || gotOpts.ProxyJump != "bastion" || gotOpts.ProxyCommand != "ssh -W %h:%p jump-host" || gotOpts.Identity != privateKey {
+		t.Fatalf("deploy opts = %#v", gotOpts)
+	}
+
+	updated, cmd = updated.Update(cmd())
+	if cmd == nil {
+		t.Fatalf("cmd = nil after deploy success, want save command")
+	}
+
+	updated, _ = updated.Update(cmd())
+	if !updated.success {
+		t.Fatalf("success = false, want host save after deploy success")
+	}
+
+	content, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "Host demo") {
+		t.Fatalf("config missing host block:\n%s", string(content))
+	}
+	if !strings.Contains(string(content), "IdentityFile "+privateKey) {
+		t.Fatalf("config missing identity:\n%s", string(content))
+	}
+}
+
+func TestAddFormCtrlDRequiresExplicitIdentity(t *testing.T) {
+	form := NewAddForm("", NewStyles(80), 80, 24, "")
+	form.inputs[nameInput].SetValue("demo")
+	form.inputs[hostnameInput].SetValue("203.0.113.10")
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if cmd != nil {
+		t.Fatalf("cmd != nil, want validation failure")
+	}
+	if !strings.Contains(updated.err, "choose or generate a key before deploy") {
+		t.Fatalf("err = %q, want explicit identity guidance", updated.err)
+	}
+}
+
+func TestEditFormSelectKeyAppliesIdentityPath(t *testing.T) {
+	form := newTestEditForm()
+	form.keyPicker = &keyPickerModel{}
+
+	updatedModel, cmd := form.Update(keyPickerSelectMsg{path: "/tmp/id_ed25519_edit"})
+	updated := updatedModel.(*editFormModel)
+
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after selection")
+	}
+	if got := updated.inputs[3].Value(); got != "/tmp/id_ed25519_edit" {
+		t.Fatalf("identity value = %q", got)
+	}
+	if updated.focusArea != focusAreaProperties || updated.currentTab != 0 || updated.focused != 3 {
+		t.Fatalf("focus = (%d,%d,%d), want properties/general/identity", updated.focusArea, updated.currentTab, updated.focused)
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want focus update command")
+	}
+}
+
+func TestEditFormFullPickerSelectionFlow(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := newTestEditForm()
+	updated := openLoadedEditPicker(t, form)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want selection command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if got := updated.inputs[3].Value(); got != "/tmp/id_ed25519_demo" {
+		t.Fatalf("identity value = %q", got)
+	}
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after full selection flow")
+	}
+}
+
+func TestEditFormOpensKeyPickerWithEnterFromIdentityField(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := newTestEditForm()
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(*editFormModel)
+	if updated.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open from Enter")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+}
+
+func TestEditFormOpensKeyCreateDirectlyFromIdentityField(t *testing.T) {
+	form := newTestEditForm()
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	updated := updatedModel.(*editFormModel)
+	if updated.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want blink command when create form opens")
+	}
+}
+
+func TestEditFormCtrlDDeploysAndThenSavesHost(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	initialConfig := "Host demo\n  HostName 203.0.113.10\n  User root\n  Port 22\n"
+	if err := os.WriteFile(configFile, []byte(initialConfig), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	keyDir := t.TempDir()
+	privateKey := keyDir + "/id_ed25519_demo"
+	publicKey := privateKey + ".pub"
+	if err := os.WriteFile(privateKey, []byte("private"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(publicKey, []byte("ssh-ed25519 AAAATEST demo\n"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	var gotOpts keypkg.DeployOptions
+	stubEditFormDeployForUITest(t, func(opts keypkg.DeployOptions) tea.Cmd {
+		gotOpts = opts
+		return func() tea.Msg { return editFormDeployFinishedMsg{} }
+	})
+
+	form, err := NewEditForm("demo", NewStyles(80), 80, 24, configFile)
+	if err != nil {
+		t.Fatalf("NewEditForm() error = %v", err)
+	}
+	form.focusArea = focusAreaProperties
+	form.currentTab = 0
+	form.focused = 3
+	form.inputs[0].SetValue("203.0.113.11")
+	form.inputs[1].SetValue("ubuntu")
+	form.inputs[2].SetValue("2222")
+	form.inputs[3].SetValue(privateKey)
+	form.inputs[4].SetValue("bastion")
+	form.inputs[5].SetValue("ssh -W %h:%p jump-host")
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	updated := updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want deploy command")
+	}
+	if gotOpts.Target != "203.0.113.11" || gotOpts.User != "ubuntu" || gotOpts.Port != "2222" || gotOpts.ProxyJump != "bastion" || gotOpts.ProxyCommand != "ssh -W %h:%p jump-host" || gotOpts.Identity != privateKey {
+		t.Fatalf("deploy opts = %#v", gotOpts)
+	}
+
+	updatedModel, cmd = updated.Update(cmd())
+	updated = updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil after deploy success, want save command")
+	}
+
+	msg := cmd()
+	submitMsg, ok := msg.(editFormSubmitMsg)
+	if !ok {
+		t.Fatalf("msg type = %T, want editFormSubmitMsg", msg)
+	}
+	if submitMsg.err != nil {
+		t.Fatalf("submit error = %v", submitMsg.err)
+	}
+
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if updated.err != "" {
+		t.Fatalf("err = %q, want empty after successful deploy+save", updated.err)
+	}
+
+	content, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	got := string(content)
+	if !strings.Contains(got, "HostName 203.0.113.11") {
+		t.Fatalf("config missing updated hostname:\n%s", got)
+	}
+	if !strings.Contains(got, "User ubuntu") {
+		t.Fatalf("config missing updated user:\n%s", got)
+	}
+	if !strings.Contains(got, "Port 2222") {
+		t.Fatalf("config missing updated port:\n%s", got)
+	}
+	if !strings.Contains(got, "IdentityFile "+privateKey) {
+		t.Fatalf("config missing identity:\n%s", got)
+	}
+}
+
+func TestEditFormCtrlDRequiresExplicitIdentity(t *testing.T) {
+	form := newTestEditForm()
+	form.inputs[0].SetValue("203.0.113.10")
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	updated := updatedModel.(*editFormModel)
+	if cmd != nil {
+		t.Fatalf("cmd != nil, want validation failure")
+	}
+	if !strings.Contains(updated.err, "choose or generate a key before deploy") {
+		t.Fatalf("err = %q, want explicit identity guidance", updated.err)
+	}
+}
+
+func TestEditFormCtrlDDeletesFocusedAliasInHostNamesArea(t *testing.T) {
+	form := newTestEditForm()
+	form.hostInputs = []textinput.Model{textinput.New(), textinput.New()}
+	form.hostInputs[0].SetValue("demo")
+	form.hostInputs[1].SetValue("demo-alt")
+	form.focusArea = focusAreaHosts
+	form.focused = 1
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	updated := updatedModel.(*editFormModel)
+	if cmd != nil {
+		t.Fatalf("cmd != nil, want in-place delete only")
+	}
+	if len(updated.hostInputs) != 1 {
+		t.Fatalf("len(hostInputs) = %d, want 1", len(updated.hostInputs))
+	}
+	if got := updated.hostInputs[0].Value(); got != "demo" {
+		t.Fatalf("remaining host = %q, want demo", got)
+	}
+}
+
+func TestEditFormPickerGOpensCreateFlow(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := newTestEditForm()
+	updated := openLoadedEditPicker(t, form)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g")})
+	updated = updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want create command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if updated.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form to open")
+	}
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after opening create flow")
+	}
+}
+
+func TestEditFormPickerEscReturnsToForm(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := newTestEditForm()
+	updated := openLoadedEditPicker(t, form)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after cancel")
+	}
+	if updated.focused != 3 {
+		t.Fatalf("focused = %d, want identity field", updated.focused)
+	}
+}
+
+func TestEditFormPickerLeftReturnsToForm(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	form := newTestEditForm()
+	updated := openLoadedEditPicker(t, form)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	updated = updatedModel.(*editFormModel)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if updated.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after cancel")
+	}
+	if updated.focused != 3 {
+		t.Fatalf("focused = %d, want identity field", updated.focused)
+	}
+}
+
+func TestKeyCreateFormRequiresName(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.inputs[keyCreateNameInput].SetValue("")
+
+	cmd := form.submit()
+	if cmd != nil {
+		t.Fatalf("cmd != nil, want validation failure before spawning process")
+	}
+	if form.err == "" {
+		t.Fatalf("err is empty, want validation error")
+	}
+}
+
+func TestKeyCreateFormAllowsLetterQInput(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+
+	updated, _ := form.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if got := updated.inputs[keyCreateNameInput].Value(); got != "q" {
+		t.Fatalf("name value = %q, want q", got)
+	}
+	if updated.err != "" {
+		t.Fatalf("err = %q, want empty", updated.err)
+	}
+}
+
+func TestKeyCreateFormRejectsAlgorithmOutsideAllowlist(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.inputs[keyCreateNameInput].SetValue("id_demo")
+	form.algorithmOptions = append(form.algorithmOptions, "dsa")
+	form.algorithmIndex = len(form.algorithmOptions) - 1
+
+	cmd := form.submit()
+	if cmd != nil {
+		t.Fatalf("cmd != nil, want validation failure")
+	}
+	if !strings.Contains(form.err, "algorithm must be one of") {
+		t.Fatalf("err = %q, want allowlist validation", form.err)
+	}
+}
+
+func TestKeyCreateFormAcceptsAllowedAlgorithm(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.inputs[keyCreateNameInput].SetValue("id_demo")
+	form.inputs[keyCreatePathInput].SetValue(t.TempDir())
+	form.algorithmIndex = 2
+
+	cmd := form.submit()
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want ssh-keygen process command")
+	}
+	if form.err != "" {
+		t.Fatalf("err = %q, want empty", form.err)
+	}
+}
+
+func TestKeyCreateFormDownFromGeneralSwitchesToAdvanced(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.focused = keyCreatePathInput
+	form.currentTab = keyCreateTabGeneral
+
+	updated, _ := form.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if updated.currentTab != keyCreateTabAdvanced {
+		t.Fatalf("currentTab = %d, want advanced", updated.currentTab)
+	}
+	if updated.focused != keyCreateAlgorithmInput {
+		t.Fatalf("focused = %d, want algorithm picker", updated.focused)
+	}
+}
+
+func TestKeyCreateFormUpFromAdvancedReturnsToGeneral(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.focused = keyCreateAlgorithmInput
+	form.currentTab = keyCreateTabAdvanced
+
+	updated, _ := form.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if updated.currentTab != keyCreateTabGeneral {
+		t.Fatalf("currentTab = %d, want general", updated.currentTab)
+	}
+	if updated.focused != keyCreatePathInput {
+		t.Fatalf("focused = %d, want directory field", updated.focused)
+	}
+}
+
+func TestKeyCreateFormRightCyclesAlgorithmPicker(t *testing.T) {
+	form := NewKeyCreateForm(NewStyles(80), 80, 24)
+	form.focused = keyCreateAlgorithmInput
+	form.currentTab = keyCreateTabAdvanced
+
+	updated, _ := form.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := updated.algorithmOptions[updated.algorithmIndex]; got != "ecdsa" {
+		t.Fatalf("algorithm = %q, want ecdsa", got)
+	}
+}
+
+func TestRootAddViewRoutesKeyPickerSelectionMessage(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.viewMode = ViewAdd
+	m.addForm = NewAddForm("", NewStyles(80), 80, 24, "")
+	m.addForm.focused = identityInput
+	m.addForm.currentTab = tabGeneral
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(Model)
+	if updated.addForm == nil || updated.addForm.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.addForm.keyPicker.loading {
+		t.Fatalf("loading = true after load command")
+	}
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want chooser callback command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(Model)
+	if got := updated.addForm.inputs[identityInput].Value(); got != "/tmp/id_ed25519_demo" {
+		t.Fatalf("identity value = %q, want selected key path", got)
+	}
+	if updated.addForm.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after routing chooser callback through root")
+	}
+}
+
+func TestRootAddViewRoutesKeyPickerCancelMessage(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.viewMode = ViewAdd
+	m.addForm = NewAddForm("", NewStyles(80), 80, 24, "")
+	m.addForm.focused = identityInput
+	m.addForm.currentTab = tabGeneral
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(Model)
+	if updated.addForm == nil || updated.addForm.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel callback command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(Model)
+	if updated.addForm.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after cancel routed through root")
+	}
+	if updated.addForm.focused != identityInput {
+		t.Fatalf("focused = %d, want identityInput", updated.addForm.focused)
+	}
+}
+
+func TestRootAddViewRoutesKeyPickerCreateMessage(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.viewMode = ViewAdd
+	m.addForm = NewAddForm("", NewStyles(80), 80, 24, "")
+	m.addForm.focused = identityInput
+	m.addForm.currentTab = tabGeneral
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(Model)
+	if updated.addForm == nil || updated.addForm.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want create callback command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(Model)
+	if updated.addForm.keyCreate == nil {
+		t.Fatalf("keyCreate = nil after routing create callback through root")
+	}
+	if updated.addForm.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after switching to create modal")
+	}
+}
+
+func TestRootEditViewRoutesKeyPickerSelectionMessage(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.viewMode = ViewEdit
+	m.editForm = newTestEditForm()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(Model)
+	if updated.editForm == nil || updated.editForm.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want chooser callback command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(Model)
+	if got := updated.editForm.inputs[3].Value(); got != "/tmp/id_ed25519_demo" {
+		t.Fatalf("identity value = %q, want selected key path", got)
+	}
+	if updated.editForm.keyPicker != nil {
+		t.Fatalf("keyPicker != nil after routing chooser callback through root")
+	}
+}
+
+func TestRootListOpensKeysView(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	updated := updatedModel.(Model)
+	if updated.viewMode != ViewKeys {
+		t.Fatalf("viewMode = %d, want ViewKeys", updated.viewMode)
+	}
+	if updated.keysView == nil {
+		t.Fatalf("keysView = nil, want keys browser")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async inventory load")
+	}
+}
+
+func TestRootKeysViewEscClosesToList(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	updated := updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async inventory load")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.browser == nil || updated.keysView.browser.loading {
+		t.Fatalf("keysView still loading after inventory refresh")
+	}
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want close callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewList {
+		t.Fatalf("viewMode = %d, want ViewList", updated.viewMode)
+	}
+	if updated.keysView != nil {
+		t.Fatalf("keysView != nil after close")
+	}
+}
+
+func TestRootKeysViewLeftClosesToList(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	updated := updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async inventory load")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.browser == nil || updated.keysView.browser.loading {
+		t.Fatalf("keysView still loading after inventory refresh")
+	}
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want close callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewList {
+		t.Fatalf("viewMode = %d, want ViewList", updated.viewMode)
+	}
+	if updated.keysView != nil {
+		t.Fatalf("keysView != nil after close")
+	}
+}
+
+func TestRootKeysViewGOpensCreateFlow(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	updated := updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async inventory load")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want create callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.keyCreate == nil {
+		t.Fatalf("keyCreate = nil, want create form inside keys view")
+	}
+}
+
+func TestRootKeysViewEnterOpensInspect(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || !updated.keysView.inspect {
+		t.Fatalf("inspect = false, want inspect mode")
+	}
+}
+
+func TestRootKeysViewInspectLoadsPublicKey(t *testing.T) {
+	tempDir := t.TempDir()
+	publicKeyPath := tempDir + "/id_ed25519_demo.pub"
+	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST demo\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:          tempDir + "/id_ed25519_demo",
+			PublicKeyPath: publicKeyPath,
+			Fingerprint:   "SHA256:test",
+			Algorithm:     "ED25519",
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want load public key command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if !updated.keysView.showPublic {
+		t.Fatalf("showPublic = false, want visible public key")
+	}
+	if got := updated.keysView.publicKey; !strings.Contains(got, "AAAATEST") {
+		t.Fatalf("publicKey = %q, want key contents", got)
+	}
+}
+
+func TestRootKeysViewInspectCopiesPublicKey(t *testing.T) {
+	tempDir := t.TempDir()
+	publicKeyPath := tempDir + "/id_ed25519_demo.pub"
+	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST demo\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	var copied string
+	stubClipboardForUITest(t, func(text string) error {
+		copied = text
+		return nil
+	})
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:          tempDir + "/id_ed25519_demo",
+			PublicKeyPath: publicKeyPath,
+			Fingerprint:   "SHA256:test",
+			Algorithm:     "ED25519",
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want clipboard command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if !strings.Contains(copied, "AAAATEST") {
+		t.Fatalf("copied = %q, want key contents", copied)
+	}
+	if got := updated.keysView.status; !strings.Contains(got, "Copied public key.") {
+		t.Fatalf("status = %q, want copy status", got)
+	}
+}
+
+func TestRootKeysViewInspectCopiesKeyPath(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKeyPath := tempDir + "/id_ed25519_demo"
+
+	var copied string
+	stubClipboardForUITest(t, func(text string) error {
+		copied = text
+		return nil
+	})
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        privateKeyPath,
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want clipboard command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if copied != privateKeyPath {
+		t.Fatalf("copied = %q, want %q", copied, privateKeyPath)
+	}
+	if got := updated.keysView.status; !strings.Contains(got, "Copied key path.") {
+		t.Fatalf("status = %q, want path copy status", got)
+	}
+}
+
+func TestRootKeysViewInspectRevealsKeyPath(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKeyPath := tempDir + "/id_ed25519_demo"
+
+	var revealed string
+	stubRevealPathForUITest(t, func(path string) error {
+		revealed = path
+		return nil
+	})
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        privateKeyPath,
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want reveal command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if revealed != privateKeyPath {
+		t.Fatalf("revealed = %q, want %q", revealed, privateKeyPath)
+	}
+	if got := updated.keysView.status; !strings.Contains(got, "Revealed id_ed25519_demo in file manager.") {
+		t.Fatalf("status = %q, want reveal status", got)
+	}
+}
+
+func TestRootKeysViewInspectTOpensAttachHostPicker(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+	stubAttachHostsForUITest(t, func(string) ([]config.SSHHost, error) {
+		return []config.SSHHost{{
+			Name:       "dev.tisit.vm",
+			Hostname:   "203.0.113.10",
+			SourceFile: "/tmp/config",
+			LineNumber: 1,
+		}}, nil
+	})
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.attachPicker == nil {
+		t.Fatalf("attachPicker = nil, want host picker")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want host load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView.attachPicker.loading {
+		t.Fatalf("attach picker still loading after callback")
+	}
+}
+
+func TestRootKeysViewAttachPickerEscReturnsToInspect(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+	stubAttachHostsForUITest(t, func(string) ([]config.SSHHost, error) {
+		return []config.SSHHost{{
+			Name:       "dev.tisit.vm",
+			Hostname:   "203.0.113.10",
+			SourceFile: "/tmp/config",
+			LineNumber: 1,
+		}}, nil
+	})
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView.attachPicker != nil {
+		t.Fatalf("attachPicker != nil after cancel")
+	}
+	if updated.keysView == nil || !updated.keysView.inspect {
+		t.Fatalf("inspect = false, want return to inspect")
+	}
+}
+
+func TestRootKeysViewAttachPickerEnterAttachesAndRefreshes(t *testing.T) {
+	originalInventoryLoader := loadKeyInventoryForUI
+	var inventoryCalls int
+	loadKeyInventoryForUI = func(context.Context, string) ([]keypkg.InventoryItem, error) {
+		inventoryCalls++
+		if inventoryCalls == 1 {
+			return []keypkg.InventoryItem{{
+				Path:        "/tmp/id_ed25519_demo",
+				Fingerprint: "SHA256:test",
+				Algorithm:   "ED25519",
+			}}, nil
+		}
+		return []keypkg.InventoryItem{{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		}}, nil
+	}
+	t.Cleanup(func() {
+		loadKeyInventoryForUI = originalInventoryLoader
+	})
+
+	stubAttachHostsForUITest(t, func(string) ([]config.SSHHost, error) {
+		return []config.SSHHost{{
+			Name:       "dev.tisit.vm",
+			Hostname:   "203.0.113.10",
+			SourceFile: "/tmp/config",
+			LineNumber: 1,
+		}}, nil
+	})
+
+	var attachedHost config.SSHHost
+	var attachedPath string
+	stubAttachKeyForUITest(t, func(host config.SSHHost, path string) tea.Cmd {
+		attachedHost = host
+		attachedPath = path
+		return func() tea.Msg {
+			return keyAttachFinishedMsg{hostName: host.Name, path: path}
+		}
+	})
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want attach host selection callback")
+	}
+
+	updatedModel, cmd = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want attach command")
+	}
+	if attachedHost.Name != "dev.tisit.vm" {
+		t.Fatalf("attachedHost = %#v", attachedHost)
+	}
+	if attachedPath != "/tmp/id_ed25519_demo" {
+		t.Fatalf("attachedPath = %q, want selected key path", attachedPath)
+	}
+
+	updatedModel, cmd = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want inventory refresh")
+	}
+	if updated.keysView.attachPicker != nil {
+		t.Fatalf("attachPicker != nil after attach success")
+	}
+	if got := updated.keysView.status; !strings.Contains(got, "Attached id_ed25519_demo to dev.tisit.vm.") {
+		t.Fatalf("status = %q, want attach status", got)
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if refs := updated.keysView.browser.items[0].References; len(refs) != 1 || refs[0].Host != "dev.tisit.vm" {
+		t.Fatalf("references = %#v, want refreshed attach reference", refs)
+	}
+}
+
+func TestRootKeysViewInspectVOpensDeployHostPicker(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+	stubAttachHostsForUITest(t, func(string) ([]config.SSHHost, error) {
+		return []config.SSHHost{{
+			Name:       "dev.tisit.vm",
+			Hostname:   "203.0.113.10",
+			SourceFile: "/tmp/config",
+			LineNumber: 1,
+		}}, nil
+	})
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v")})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.deployPicker == nil {
+		t.Fatalf("deployPicker = nil, want host picker")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want host load command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView.deployPicker.loading {
+		t.Fatalf("deploy picker still loading after callback")
+	}
+}
+
+func TestRootKeysViewDeployPickerEnterDeploysKey(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+		},
+	}, nil)
+	stubAttachHostsForUITest(t, func(string) ([]config.SSHHost, error) {
+		return []config.SSHHost{{
+			Name:         "dev.tisit.vm",
+			Hostname:     "203.0.113.10",
+			User:         "ubuntu",
+			Port:         "2222",
+			ProxyJump:    "bastion",
+			ProxyCommand: "ssh -W %h:%p jump-host",
+			SourceFile:   "/tmp/config",
+			LineNumber:   1,
+		}}, nil
+	})
+
+	var deployedHost config.SSHHost
+	var deployedPath string
+	var deployedConfigFile string
+	stubDeployKeyForUITest(t, func(host config.SSHHost, path string, configFile string) tea.Cmd {
+		deployedHost = host
+		deployedPath = path
+		deployedConfigFile = configFile
+		return func() tea.Msg {
+			return keyDeployFinishedMsg{hostName: host.Name, path: path}
+		}
+	})
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = "/tmp/custom-config"
+	updated := openLoadedKeysView(t, m)
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v")})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want deploy host selection callback")
+	}
+
+	updatedModel, cmd = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want deploy command")
+	}
+	if deployedHost.Name != "dev.tisit.vm" {
+		t.Fatalf("deployedHost = %#v", deployedHost)
+	}
+	if deployedPath != "/tmp/id_ed25519_demo" {
+		t.Fatalf("deployedPath = %q, want selected key path", deployedPath)
+	}
+	if deployedConfigFile != "/tmp/custom-config" {
+		t.Fatalf("deployedConfigFile = %q, want custom config", deployedConfigFile)
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView.deployPicker != nil {
+		t.Fatalf("deployPicker != nil after deploy success")
+	}
+	if got := updated.keysView.status; !strings.Contains(got, "Deployed id_ed25519_demo to dev.tisit.vm.") {
+		t.Fatalf("status = %q, want deploy status", got)
+	}
+}
+
+func TestRootKeysViewInspectDeleteBlockedWhenDeclaredRefsExist(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || !updated.keysView.deleteDialog || !updated.keysView.deleteBlocked {
+		t.Fatalf("delete dialog not blocked as expected")
+	}
+}
+
+func TestRootKeysViewInspectDeleteBlockedUsesExplicitAttachCopy(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+				{Host: "github.com"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	updated = updatedModel.(Model)
+
+	view := updated.keysView.View()
+	if !strings.Contains(view, "This key is explicitly referenced by these SSH hosts:") {
+		t.Fatalf("blocking copy prefix missing:\n%s", view)
+	}
+	if !strings.Contains(view, "dev.tisit.vm") || !strings.Contains(view, "github.com") {
+		t.Fatalf("blocked hosts missing:\n%s", view)
+	}
+}
+
+func TestRootKeysViewInspectDeleteConfirmWarnsAboutUnknownImplicitUsage(t *testing.T) {
+	privateKeyPath := "/tmp/id_ed25519_demo"
+	publicKeyPath := privateKeyPath + ".pub"
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:          privateKeyPath,
+			PublicKeyPath: publicKeyPath,
+			Fingerprint:   "SHA256:test",
+			Algorithm:     "ED25519",
+			CanDelete:     true,
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	updated = updatedModel.(Model)
+
+	view := updated.keysView.View()
+	if !strings.Contains(view, "Delete key") {
+		t.Fatalf("delete heading missing:\n%s", view)
+	}
+	if !strings.Contains(view, displayPath(privateKeyPath)) {
+		t.Fatalf("delete title missing:\n%s", view)
+	}
+	if !strings.Contains(view, "No explicit IdentityFile entries point to this key.") {
+		t.Fatalf("explicit refs warning missing:\n%s", view)
+	}
+	if !strings.Contains(view, "SSHM can't verify inherited or external SSH config.") {
+		t.Fatalf("implicit usage warning prefix missing:\n%s", view)
+	}
+}
+
+func TestRootKeysViewInspectDeleteRemovesFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	privateKeyPath := tempDir + "/id_ed25519_demo"
+	publicKeyPath := privateKeyPath + ".pub"
+	if err := os.WriteFile(privateKeyPath, []byte("private"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(publicKeyPath, []byte("public"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:          privateKeyPath,
+			PublicKeyPath: publicKeyPath,
+			Fingerprint:   "SHA256:test",
+			Algorithm:     "ED25519",
+			CanDelete:     true,
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || !updated.keysView.deleteDialog || updated.keysView.deleteBlocked {
+		t.Fatalf("delete dialog = %+v, want confirm dialog", updated.keysView)
+	}
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want delete command")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if _, err := os.Stat(privateKeyPath); !os.IsNotExist(err) {
+		t.Fatalf("private key still exists, err = %v", err)
+	}
+	if _, err := os.Stat(publicKeyPath); !os.IsNotExist(err) {
+		t.Fatalf("public key still exists, err = %v", err)
+	}
+	if updated.keysView == nil || updated.keysView.inspect {
+		t.Fatalf("inspect = true, want return to list after delete")
+	}
+}
+
+func TestRootKeysViewInspectHOpensLinkedHosts(t *testing.T) {
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+				{Host: "github.com"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || !updated.keysView.hostRefs {
+		t.Fatalf("hostRefs = false, want linked hosts view")
+	}
+}
+
+func TestRootKeysViewLinkedHostsEnterOpensHostInfo(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	if err := os.WriteFile(configFile, []byte("Host dev.tisit.vm\n  HostName 127.0.0.1\n  User root\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = configFile
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want open host info callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewInfo {
+		t.Fatalf("viewMode = %d, want ViewInfo", updated.viewMode)
+	}
+	if updated.infoForm == nil || updated.infoForm.hostName != "dev.tisit.vm" {
+		t.Fatalf("infoForm host = %#v, want dev.tisit.vm", updated.infoForm)
+	}
+}
+
+func TestRootKeysViewLinkedHostsUsesReferenceSourceFileForHostInfo(t *testing.T) {
+	tempDir := t.TempDir()
+	mainConfig := tempDir + "/config"
+	includedConfig := tempDir + "/included.conf"
+	if err := os.WriteFile(mainConfig, []byte("Host shared\n  HostName main.example.com\nInclude included.conf\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.WriteFile(includedConfig, []byte("Host shared\n  HostName included.example.com\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "shared", SourceFile: includedConfig},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = mainConfig
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want open host info callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.infoForm == nil || updated.infoForm.host.Hostname != "included.example.com" {
+		t.Fatalf("info host = %#v, want included host", updated.infoForm)
+	}
+}
+
+func TestRootKeysViewLinkedHostsEOpensHostEdit(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	if err := os.WriteFile(configFile, []byte("Host dev.tisit.vm\n  HostName 127.0.0.1\n  User root\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = configFile
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want open host edit callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewEdit {
+		t.Fatalf("viewMode = %d, want ViewEdit", updated.viewMode)
+	}
+	if updated.editForm == nil {
+		t.Fatalf("editForm = nil, want edit form")
+	}
+}
+
+func TestRootKeysHostInfoEscReturnsToLinkedHosts(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	if err := os.WriteFile(configFile, []byte("Host dev.tisit.vm\n  HostName 127.0.0.1\n  User root\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = configFile
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want open host info callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewInfo {
+		t.Fatalf("viewMode = %d, want ViewInfo", updated.viewMode)
+	}
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewKeys {
+		t.Fatalf("viewMode = %d, want ViewKeys", updated.viewMode)
+	}
+	if updated.keysView == nil || !updated.keysView.hostRefs {
+		t.Fatalf("keysView = %#v, want linked hosts state preserved", updated.keysView)
+	}
+}
+
+func TestRootKeysHostEditEscReturnsToLinkedHosts(t *testing.T) {
+	configFile := t.TempDir() + "/config"
+	if err := os.WriteFile(configFile, []byte("Host dev.tisit.vm\n  HostName 127.0.0.1\n  User root\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	stubKeyInventoryForUITest(t, []keypkg.InventoryItem{
+		{
+			Path:        "/tmp/id_ed25519_demo",
+			Fingerprint: "SHA256:test",
+			Algorithm:   "ED25519",
+			References: []keypkg.Reference{
+				{Host: "dev.tisit.vm"},
+			},
+		},
+	}, nil)
+
+	m := newKeyWorkflowRootModel()
+	m.configFile = configFile
+	updated := openLoadedKeysView(t, m)
+
+	updatedModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	updated = updatedModel.(Model)
+	updatedModel, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want open host edit callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewEdit {
+		t.Fatalf("viewMode = %d, want ViewEdit", updated.viewMode)
+	}
+
+	updatedModel, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want cancel callback")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.viewMode != ViewKeys {
+		t.Fatalf("viewMode = %d, want ViewKeys", updated.viewMode)
+	}
+	if updated.keysView == nil || !updated.keysView.hostRefs {
+		t.Fatalf("keysView = %#v, want linked hosts state preserved", updated.keysView)
+	}
+}
+
+func TestAddFormCompactViewAtHeight15(t *testing.T) {
+	form := NewAddForm("", NewStyles(80), 80, 15, "")
+	view := form.View()
+	if strings.Contains(view, "Terminal height is too small") {
+		t.Fatalf("unexpected height warning in compact mode:\n%s", view)
+	}
+	if !strings.Contains(view, "Compact mode") {
+		t.Fatalf("compact mode marker missing:\n%s", view)
+	}
+}
+
+func TestEditFormCompactViewAtHeight15(t *testing.T) {
+	form := newTestEditForm()
+	form.height = 15
+	view := form.View()
+	if strings.Contains(view, "Terminal height is too small") {
+		t.Fatalf("unexpected height warning in compact mode:\n%s", view)
+	}
+	if !strings.Contains(view, "Compact mode") {
+		t.Fatalf("compact mode marker missing:\n%s", view)
+	}
+}
+
+func TestKeyPickerViewUsesBasenameAndTildePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	picker := &keyPickerModel{
+		items: []keypkg.InventoryItem{
+			{
+				Path:          home + "/.ssh/id_ed25519_demo",
+				PublicKeyPath: home + "/.ssh/id_ed25519_demo.pub",
+				Permissions:   "0600",
+				Fingerprint:   "SHA256:testfingerprint",
+				Algorithm:     "ED25519",
+				References: []keypkg.Reference{
+					{Host: "dev.tisit.vm"},
+					{Host: "github.com"},
+				},
+			},
+		},
+		selected:  0,
+		styles:    NewStyles(100),
+		width:     100,
+		height:    30,
+		backLabel: "Edit Host",
+		title:     "For dev.tisit.vm",
+	}
+
+	view := picker.View()
+	if !strings.Contains(view, "Name") {
+		t.Fatalf("name header missing:\n%s", view)
+	}
+	if strings.Contains(view, "Used By") {
+		t.Fatalf("unexpected Used By label:\n%s", view)
+	}
+	if strings.Contains(view, "Selected:") {
+		t.Fatalf("unexpected Selected label:\n%s", view)
+	}
+	if strings.Contains(view, "Showing explicit IdentityFile references only.") {
+		t.Fatalf("unexpected disclaimer line:\n%s", view)
+	}
+	if !strings.Contains(view, "id_ed25519_demo") {
+		t.Fatalf("basename missing:\n%s", view)
+	}
+	if !strings.Contains(view, "~/.ssh/id_ed25519_demo") {
+		t.Fatalf("tilde path missing:\n%s", view)
+	}
+	if !strings.Contains(view, "2 hosts") {
+		t.Fatalf("reference count summary missing:\n%s", view)
+	}
+	if !strings.Contains(view, "← back to Edit Host") {
+		t.Fatalf("back label missing:\n%s", view)
+	}
+	if !strings.Contains(view, "esc/← back") {
+		t.Fatalf("left-arrow back hint missing:\n%s", view)
+	}
+}
+
+func TestInspectViewShowsPathActions(t *testing.T) {
+	keysView := &keysViewModel{
+		browser: &keyPickerModel{
+			items: []keypkg.InventoryItem{
+				{
+					Path:        "/tmp/id_ed25519_demo",
+					Fingerprint: "SHA256:test",
+					Algorithm:   "ED25519",
+				},
+			},
+			selected: 0,
+			loading:  false,
+		},
+		styles:  NewStyles(100),
+		width:   100,
+		height:  30,
+		inspect: true,
+	}
+
+	view := keysView.View()
+	if !strings.Contains(view, "y copy path") {
+		t.Fatalf("copy path hint missing:\n%s", view)
+	}
+	if !strings.Contains(view, "o reveal path") {
+		t.Fatalf("reveal path hint missing:\n%s", view)
+	}
+	if !strings.Contains(view, "v deploy to host") {
+		t.Fatalf("deploy hint missing:\n%s", view)
+	}
+}
+
+func TestKeyBrowserViewOmitsChooseHint(t *testing.T) {
+	browser := NewKeyBrowser("Main screen", NewStyles(100), 100, 30, "")
+	browser.loading = false
+	browser.items = []keypkg.InventoryItem{
+		{Path: "/tmp/id_ed25519_demo", Fingerprint: "SHA256:test", Algorithm: "ED25519"},
+	}
+
+	view := browser.View()
+	if strings.Contains(view, "enter choose") {
+		t.Fatalf("unexpected chooser hint in browse mode:\n%s", view)
+	}
+	if !strings.Contains(view, "g generate") {
+		t.Fatalf("generate hint missing:\n%s", view)
+	}
+	if !strings.Contains(view, "/tmp/id_ed25519_demo") {
+		t.Fatalf("selected path missing in browse mode:\n%s", view)
+	}
+}
+
+func TestKeyPickerViewKeepsFullPathOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	picker := &keyPickerModel{
+		items: []keypkg.InventoryItem{
+			{
+				Path:        "/opt/keys/id_vm_custom",
+				Permissions: "0600",
+				Fingerprint: "SHA256:testfingerprint",
+				Algorithm:   "ED25519",
+			},
+		},
+		selected: 0,
+		styles:   NewStyles(100),
+		width:    100,
+		height:   30,
+	}
+
+	view := picker.View()
+	if !strings.Contains(view, "/opt/keys/id_vm_custom") {
+		t.Fatalf("full path missing for non-home key:\n%s", view)
+	}
+}
+
+func newTestEditForm() *editFormModel {
+	inputs := make([]textinput.Model, 10)
+	for i := range inputs {
+		inputs[i] = textinput.New()
+	}
+
+	return &editFormModel{
+		inputs:     inputs,
+		focusArea:  focusAreaProperties,
+		focused:    3,
+		currentTab: 0,
+		styles:     NewStyles(80),
+		width:      80,
+		height:     24,
+	}
+}
+
+func openLoadedAddPicker(t *testing.T, form *addFormModel) *addFormModel {
+	t.Helper()
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if updated.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	msg := cmd()
+	updated, _ = updated.Update(msg)
+	if updated.keyPicker == nil || updated.keyPicker.loading {
+		t.Fatalf("picker still loading after async load")
+	}
+	return updated
+}
+
+func openLoadedEditPicker(t *testing.T, form *editFormModel) *editFormModel {
+	t.Helper()
+
+	updatedModel, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(*editFormModel)
+	if updated.keyPicker == nil {
+		t.Fatalf("keyPicker = nil, want picker to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async load command")
+	}
+
+	msg := cmd()
+	updatedModel, _ = updated.Update(msg)
+	updated = updatedModel.(*editFormModel)
+	if updated.keyPicker == nil || updated.keyPicker.loading {
+		t.Fatalf("picker still loading after async load")
+	}
+	return updated
+}
+
+func openLoadedKeysView(t *testing.T, model Model) Model {
+	t.Helper()
+
+	updatedModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	updated := updatedModel.(Model)
+	if updated.keysView == nil {
+		t.Fatalf("keysView = nil, want keys view to open")
+	}
+	if cmd == nil {
+		t.Fatalf("cmd = nil, want async inventory load")
+	}
+
+	updatedModel, _ = updated.Update(cmd())
+	updated = updatedModel.(Model)
+	if updated.keysView == nil || updated.keysView.browser == nil || updated.keysView.browser.loading {
+		t.Fatalf("keysView still loading after async load")
+	}
+
+	return updated
+}
+
+func newKeyWorkflowRootModel() Model {
+	return Model{
+		viewMode:    ViewList,
+		ready:       true,
+		width:       80,
+		height:      24,
+		styles:      NewStyles(80),
+		searchInput: textinput.New(),
+		table:       table.New(),
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -40,6 +40,7 @@ const (
 	ViewMove
 	ViewInfo
 	ViewPortForward
+	ViewKeys
 	ViewHelp
 	ViewFileSelector
 )
@@ -96,8 +97,10 @@ type Model struct {
 	moveForm         *moveFormModel
 	infoForm         *infoFormModel
 	portForwardForm  *portForwardModel
+	keysView         *keysViewModel
 	helpForm         *helpModel
 	fileSelectorForm *fileSelectorModel
+	returnToKeys     bool
 
 	// Terminal size and styles
 	width  int

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -125,6 +125,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.portForwardForm.height = m.height
 			m.portForwardForm.styles = m.styles
 		}
+		if m.keysView != nil {
+			m.keysView.width = m.width
+			m.keysView.height = m.height
+			m.keysView.styles = m.styles
+		}
 		if m.helpForm != nil {
 			m.helpForm.width = m.width
 			m.helpForm.height = m.height
@@ -134,6 +139,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.fileSelectorForm.width = m.width
 			m.fileSelectorForm.height = m.height
 			m.fileSelectorForm.styles = m.styles
+		}
+
+		if routedModel, routedCmd, ok := m.routeActiveSubviewMsg(msg); ok {
+			return routedModel, routedCmd
 		}
 		return m, nil
 
@@ -243,16 +252,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			m.updateTableRows()
-			m.viewMode = ViewList
 			m.editForm = nil
+			if m.returnToKeys {
+				m.returnToKeys = false
+				m.keysView = NewKeysView(m.styles, m.width, m.height, m.configFile)
+				m.viewMode = ViewKeys
+				return m, m.keysView.Init()
+			}
+			m.viewMode = ViewList
 			m.table.Focus()
 			return m, nil
 		}
 
 	case editFormCancelMsg:
-		// Cancel: return to list view
-		m.viewMode = ViewList
 		m.editForm = nil
+		if m.returnToKeys && m.keysView != nil {
+			m.returnToKeys = false
+			m.viewMode = ViewKeys
+			return m, nil
+		}
+		m.viewMode = ViewList
 		m.table.Focus()
 		return m, nil
 
@@ -303,9 +322,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case infoFormCancelMsg:
-		// Cancel: return to list view
-		m.viewMode = ViewList
 		m.infoForm = nil
+		if m.returnToKeys && m.keysView != nil {
+			m.returnToKeys = false
+			m.viewMode = ViewKeys
+			return m, nil
+		}
+		m.viewMode = ViewList
 		m.table.Focus()
 		return m, nil
 
@@ -336,6 +359,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.editForm = editForm
 		m.infoForm = nil
+		m.viewMode = ViewEdit
+		return m, textinput.Blink
+
+	case keyOpenHostInfoMsg:
+		configFile := m.configFile
+		if msg.configFile != "" {
+			configFile = msg.configFile
+		}
+		infoForm, err := NewInfoForm(msg.hostName, m.styles, m.width, m.height, configFile)
+		if err != nil {
+			if m.keysView != nil {
+				m.keysView.status = err.Error()
+				m.keysView.statusErr = true
+				m.keysView.hostRefs = false
+			}
+			return m, nil
+		}
+		m.infoForm = infoForm
+		m.returnToKeys = true
+		m.viewMode = ViewInfo
+		return m, nil
+
+	case keyOpenHostEditMsg:
+		configFile := m.configFile
+		if msg.configFile != "" {
+			configFile = msg.configFile
+		}
+		editForm, err := NewEditForm(msg.hostName, m.styles, m.width, m.height, configFile)
+		if err != nil {
+			if m.keysView != nil {
+				m.keysView.status = err.Error()
+				m.keysView.statusErr = true
+				m.keysView.hostRefs = false
+			}
+			return m, nil
+		}
+		m.editForm = editForm
+		m.returnToKeys = true
 		m.viewMode = ViewEdit
 		return m, textinput.Blink
 
@@ -385,65 +446,90 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.table.Focus()
 		return m, nil
 
+	case keysViewCloseMsg:
+		m.viewMode = ViewList
+		m.keysView = nil
+		m.returnToKeys = false
+		m.table.Focus()
+		return m, nil
+
+	case keyPickerSelectMsg, keyPickerCancelMsg, keyPickerCreateMsg, keyCreateFinishedMsg, keyCreateCancelMsg:
+		if routedModel, routedCmd, ok := m.routeActiveSubviewMsg(msg); ok {
+			return routedModel, routedCmd
+		}
+		return m, nil
+
 	case tea.KeyMsg:
-		// Handle view-specific key presses
-		switch m.viewMode {
-		case ViewAdd:
-			if m.addForm != nil {
-				var newForm *addFormModel
-				newForm, cmd = m.addForm.Update(msg)
-				m.addForm = newForm
-				return m, cmd
-			}
-		case ViewEdit:
-			if m.editForm != nil {
-				var updatedModel tea.Model
-				updatedModel, cmd = m.editForm.Update(msg)
-				m.editForm = updatedModel.(*editFormModel)
-				return m, cmd
-			}
-		case ViewMove:
-			if m.moveForm != nil {
-				var newForm *moveFormModel
-				newForm, cmd = m.moveForm.Update(msg)
-				m.moveForm = newForm
-				return m, cmd
-			}
-		case ViewInfo:
-			if m.infoForm != nil {
-				var newForm *infoFormModel
-				newForm, cmd = m.infoForm.Update(msg)
-				m.infoForm = newForm
-				return m, cmd
-			}
-		case ViewPortForward:
-			if m.portForwardForm != nil {
-				var newForm *portForwardModel
-				newForm, cmd = m.portForwardForm.Update(msg)
-				m.portForwardForm = newForm
-				return m, cmd
-			}
-		case ViewHelp:
-			if m.helpForm != nil {
-				var newForm *helpModel
-				newForm, cmd = m.helpForm.Update(msg)
-				m.helpForm = newForm
-				return m, cmd
-			}
-		case ViewFileSelector:
-			if m.fileSelectorForm != nil {
-				var newForm *fileSelectorModel
-				newForm, cmd = m.fileSelectorForm.Update(msg)
-				m.fileSelectorForm = newForm
-				return m, cmd
-			}
-		case ViewList:
-			// Handle list view keys
-			return m.handleListViewKeys(msg)
+		if routedModel, routedCmd, ok := m.routeActiveSubviewMsg(msg); ok {
+			return routedModel, routedCmd
 		}
 	}
 
+	if routedModel, routedCmd, ok := m.routeActiveSubviewMsg(msg); ok {
+		return routedModel, routedCmd
+	}
+
 	return m, cmd
+}
+
+func (m Model) routeActiveSubviewMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch m.viewMode {
+	case ViewAdd:
+		if m.addForm != nil {
+			newForm, cmd := m.addForm.Update(msg)
+			m.addForm = newForm
+			return m, cmd, true
+		}
+	case ViewEdit:
+		if m.editForm != nil {
+			updatedModel, cmd := m.editForm.Update(msg)
+			m.editForm = updatedModel.(*editFormModel)
+			return m, cmd, true
+		}
+	case ViewMove:
+		if m.moveForm != nil {
+			newForm, cmd := m.moveForm.Update(msg)
+			m.moveForm = newForm
+			return m, cmd, true
+		}
+	case ViewInfo:
+		if m.infoForm != nil {
+			newForm, cmd := m.infoForm.Update(msg)
+			m.infoForm = newForm
+			return m, cmd, true
+		}
+	case ViewPortForward:
+		if m.portForwardForm != nil {
+			newForm, cmd := m.portForwardForm.Update(msg)
+			m.portForwardForm = newForm
+			return m, cmd, true
+		}
+	case ViewKeys:
+		if m.keysView != nil {
+			newForm, cmd := m.keysView.Update(msg)
+			m.keysView = newForm
+			return m, cmd, true
+		}
+	case ViewHelp:
+		if m.helpForm != nil {
+			newForm, cmd := m.helpForm.Update(msg)
+			m.helpForm = newForm
+			return m, cmd, true
+		}
+	case ViewFileSelector:
+		if m.fileSelectorForm != nil {
+			newForm, cmd := m.fileSelectorForm.Update(msg)
+			m.fileSelectorForm = newForm
+			return m, cmd, true
+		}
+	case ViewList:
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			model, cmd := m.handleListViewKeys(keyMsg)
+			return model, cmd, true
+		}
+	}
+
+	return m, nil, false
 }
 
 func (m Model) handleListViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -701,6 +787,13 @@ func (m Model) handleListViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.viewMode = ViewPortForward
 				return m, textinput.Blink
 			}
+		}
+	case "K":
+		if !m.searchMode && !m.deleteMode {
+			m.keysView = NewKeysView(m.styles, m.width, m.height, m.configFile)
+			m.returnToKeys = false
+			m.viewMode = ViewKeys
+			return m, m.keysView.Init()
 		}
 	case "h":
 		if !m.searchMode && !m.deleteMode {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -35,6 +35,10 @@ func (m Model) View() string {
 		if m.portForwardForm != nil {
 			return m.portForwardForm.View()
 		}
+	case ViewKeys:
+		if m.keysView != nil {
+			return m.keysView.View()
+		}
 	case ViewHelp:
 		if m.helpForm != nil {
 			return m.helpForm.View()
@@ -114,7 +118,7 @@ func (m Model) renderListView() string {
 	// Add the help text
 	var helpText string
 	if !m.searchMode {
-		helpText = " ↑/↓: navigate • Enter: connect • p: ping all • i: info • h: help • q: quit"
+		helpText = " ↑/↓: navigate • Enter: connect • K: keys • p: ping all • i: info • h: help • q: quit"
 	} else {
 		helpText = " Type to filter • Enter: validate • Tab: switch • ESC: quit"
 	}


### PR DESCRIPTION
feat: add end-to-end ssh key helper workflow for cli and tui

what:

- add key command flow for add, generate, list, attach, and deploy
- implement key domain logic for inventory, agent, attach, deploy, and execution paths
- integrate key workflow screens and attach picker into tui update/view state
- extend ssh and attach config handling for the new workflow
- add broad test coverage across cmd, config, key, and ui packages

why: create the seamless flow for ke management for sshm

keys list menu:
<img width="708" height="382" alt="image" src="https://github.com/user-attachments/assets/ec7a4ef5-db9e-4300-af79-13722e4b6570" />

key generation tab:
<img width="688" height="320" alt="image" src="https://github.com/user-attachments/assets/92694c91-cf34-49c1-91c7-270160ce681a" />

new look of the key field in edit/add host form:
<img width="647" height="66" alt="image" src="https://github.com/user-attachments/assets/a1ddb6c7-0cf8-43c0-b880-8522ebe646d2" />
