### PR TITLE
feat: add `# FileTags:` directive for file-wide inherited tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Besides per-host `# Tags:`, SSHM recognizes a `# FileTags:` directive placed in 
 - Multiple `# FileTags:` lines in the header accumulate (union).
 - The union with a host's own `# Tags:` is deduplicated. Inherited tags participate in search, filtering, and autocompletion just like own tags.
 - Inherited tags are **read-only** in the edit form: you cannot remove them from an individual host — edit the `# FileTags:` directive directly if you want to change them.
+- The special `hidden` tag works at the file level too: `# FileTags: hidden` hides every host in that file from the TUI and `sshm search` (they remain connectable via `sshm <host>`).
 
 **Visual distinction in the TUI:** own tags are prefixed with `#`, inherited tags with `%` — so `%prod %eu #db` tells you `prod` and `eu` come from the file header while `db` is host-specific.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SSHM is a beautiful command-line tool that transforms how you manage and connect
 - **⚡ Quick Connect** - Connect to any host instantly through the TUI or the CLI with `sshm <host>`
 - **🔄 Port Forwarding** - Easy setup for Local, Remote, and Dynamic (SOCKS) forwarding with history persistence
 - **📝 Easy Management** - Add, edit, move, and manage SSH configurations seamlessly
-- **🏷️ Tag Support** - Organize your hosts with custom tags for better categorization; use the special `hidden` tag to exclude hosts from the list while keeping them connectable
+- **🏷️ Tag Support** - Organize your hosts with custom tags for better categorization; declare file-wide tags via `# FileTags:` so every host in a config file inherits them; use the special `hidden` tag to exclude hosts from the list while keeping them connectable
 - **🔍 Smart Search** - Find hosts quickly with built-in filtering and search
 - **📝 Real-time Status** - Live SSH connectivity indicators with asynchronous ping checks and color-coded status
 - **🔔 Smart Updates** - Automatic version checking with update notifications
@@ -556,6 +556,40 @@ SSHM remembers your port forwarding configurations for easy reuse:
 
 SSHM works directly with your standard SSH configuration file (`~/.ssh/config`). It adds special comment tags for enhanced functionality while maintaining full compatibility with standard SSH tools.
 
+### File-level Tags (`# FileTags:`)
+
+Besides per-host `# Tags:`, SSHM recognizes a `# FileTags:` directive placed in the header of a config file. Every host defined in that file inherits those tags automatically — useful when a whole file groups hosts that share an attribute (a project, an environment, a region).
+
+**Rules:**
+- Must appear **before the first `Host` or `Include`** in the file. Later occurrences are ignored.
+- **Strictly local to the file** — inherited tags do NOT cascade across `Include` boundaries.
+- Multiple `# FileTags:` lines in the header accumulate (union).
+- The union with a host's own `# Tags:` is deduplicated. Inherited tags participate in search, filtering, and autocompletion just like own tags.
+- Inherited tags are **read-only** in the edit form: you cannot remove them from an individual host — edit the `# FileTags:` directive directly if you want to change them.
+
+**Visual distinction in the TUI:** own tags are prefixed with `#`, inherited tags with `%` — so `%prod %eu #db` tells you `prod` and `eu` come from the file header while `db` is host-specific.
+
+**Example:**
+```ssh
+# ~/.ssh/config.d/prod
+# FileTags: prod, critical
+
+# Tags: db
+Host demo-db
+    HostName 10.0.0.1
+    User admin
+
+Host demo-web
+    HostName 10.0.0.2
+    User admin
+```
+
+Resulting tags:
+- `demo-db` → `%prod %critical #db`
+- `demo-web` → `%prod %critical`
+
+Both hosts match `sshm search --tags prod`. `sshm info demo-db --pretty` returns `tags` (union) and a separate `inheritedTags` array.
+
 ### SSH Include Support
 
 SSHM fully supports SSH Include directives, allowing you to organize your SSH configurations across multiple files. This is particularly useful for managing large numbers of hosts or organizing configurations by environment, project, or team.
@@ -649,6 +683,7 @@ SSHM supports all standard SSH configuration options:
 - `ProxyJump` - Jump server for connection tunneling (e.g., `user@jumphost:port`)
 - `ProxyCommand` - Jump command for connection tunneling (e.g, `ssh -W %h:%p Jumphost`)
 - `Tags` - Custom tags (SSHM extension); the special tag `hidden` hides the host from the TUI and `sshm search` while keeping it connectable via `sshm <host>`
+- `FileTags` - File-scoped tags (SSHM extension); declared via a `# FileTags:` comment at the top of a config file and inherited by every host defined in that file (see [File-level Tags](#file-level-tags-filetags) below)
 
 **Additional SSH Options:**
 You can add any valid SSH option using the "SSH Options" field in the interactive forms. Enter them in command-line format (e.g., `-o Compression=yes -o ServerAliveInterval=60`) and SSHM will automatically convert them to the proper SSH config format.

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -28,6 +28,7 @@ type infoResult struct {
 	ProxyCommand  *string     `json:"proxy_command"`
 	Options       *string     `json:"options"`
 	Tags          []string    `json:"tags"`
+	InheritedTags []string    `json:"inheritedTags,omitempty"`
 	RemoteCommand *string     `json:"remote_command"`
 	RequestTTY    *string     `json:"request_tty"`
 	Source        *infoSource `json:"source"`
@@ -135,7 +136,8 @@ func runInfo(out io.Writer, hostnameArg string, cfgFile string, pretty bool) int
 		ProxyJump:     maybeString(host.ProxyJump),
 		ProxyCommand:  maybeString(host.ProxyCommand),
 		Options:       maybeString(host.Options),
-		Tags:          host.Tags,
+		Tags:          host.AllTags(),
+		InheritedTags: host.InheritedTags,
 		RemoteCommand: maybeString(host.RemoteCommand),
 		RequestTTY:    maybeString(host.RequestTTY),
 		Source: &infoSource{

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -116,7 +116,7 @@ func filterHosts(hosts []config.SSHHost, query string, tagsOnly, namesOnly bool)
 
 		// Search in tags if not names-only
 		if !namesOnly && !matched {
-			for _, tag := range host.Tags {
+			for _, tag := range host.AllTags() {
 				if strings.Contains(strings.ToLower(tag), query) {
 					matched = true
 					break
@@ -154,7 +154,7 @@ func outputTable(hosts []config.SSHHost) {
 		if len(host.User) > userWidth {
 			userWidth = len(host.User)
 		}
-		tagsStr := strings.Join(host.Tags, ", ")
+		tagsStr := strings.Join(host.AllTags(), ", ")
 		if len(tagsStr) > tagsWidth {
 			tagsWidth = len(tagsStr)
 		}
@@ -180,7 +180,7 @@ func outputTable(hosts []config.SSHHost) {
 		if user == "" {
 			user = "-"
 		}
-		tags := strings.Join(host.Tags, ", ")
+		tags := strings.Join(host.AllTags(), ", ")
 		if tags == "" {
 			tags = "-"
 		}
@@ -211,9 +211,10 @@ func outputJSON(hosts []config.SSHHost) {
 		fmt.Printf("    \"proxy_command\": \"%s\",\n", escapeJSON(host.ProxyCommand))
 		fmt.Printf("    \"options\": \"%s\",\n", escapeJSON(host.Options))
 		fmt.Printf("    \"tags\": [")
-		for j, tag := range host.Tags {
+		allTags := host.AllTags()
+		for j, tag := range allTags {
 			fmt.Printf("\"%s\"", escapeJSON(tag))
-			if j < len(host.Tags)-1 {
+			if j < len(allTags)-1 {
 				fmt.Printf(", ")
 			}
 		}

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/Gu1llaum-3/sshm/internal/config"
 )
 
 func TestSearchCommand(t *testing.T) {
@@ -102,6 +104,22 @@ func TestFormatOutput(t *testing.T) {
 				t.Errorf("isValidFormat(%q) = %v, want %v", tt.format, valid, tt.valid)
 			}
 		})
+	}
+}
+
+func TestSearchByTag_MatchesInheritedTags(t *testing.T) {
+	hosts := []config.SSHHost{
+		{Name: "h1", InheritedTags: []string{"prod"}},
+		{Name: "h2", Tags: []string{"prod"}},
+		{Name: "h3", Tags: []string{"dev"}, InheritedTags: []string{"staging"}},
+	}
+	got := filterHostsByTag(hosts, "prod")
+	if len(got) != 2 {
+		t.Errorf("filterHostsByTag('prod') returned %d hosts, want 2", len(got))
+	}
+	gotStaging := filterHostsByTag(hosts, "staging")
+	if len(gotStaging) != 1 || gotStaging[0].Name != "h3" {
+		t.Errorf("filterHostsByTag('staging') = %v, want [h3]", gotStaging)
 	}
 }
 

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -113,13 +113,13 @@ func TestSearchByTag_MatchesInheritedTags(t *testing.T) {
 		{Name: "h2", Tags: []string{"prod"}},
 		{Name: "h3", Tags: []string{"dev"}, InheritedTags: []string{"staging"}},
 	}
-	got := filterHostsByTag(hosts, "prod")
+	got := filterHosts(hosts, "prod", true, false)
 	if len(got) != 2 {
-		t.Errorf("filterHostsByTag('prod') returned %d hosts, want 2", len(got))
+		t.Errorf("filterHosts(tagsOnly, 'prod') returned %d hosts, want 2", len(got))
 	}
-	gotStaging := filterHostsByTag(hosts, "staging")
+	gotStaging := filterHosts(hosts, "staging", true, false)
 	if len(gotStaging) != 1 || gotStaging[0].Name != "h3" {
-		t.Errorf("filterHostsByTag('staging') = %v, want [h3]", gotStaging)
+		t.Errorf("filterHosts(tagsOnly, 'staging') = %v, want [h3]", gotStaging)
 	}
 }
 

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -44,6 +44,29 @@ type SSHHost struct {
 	aliasNames []string `json:"-"` // Do not serialize this field
 }
 
+// FormattedTags returns AllTags() with a prefix per tag: "%" for inherited
+// tags (from `# FileTags:`), "#" for the host's own tags. Order matches
+// AllTags (inherited first). Returns nil if both are empty.
+func (h *SSHHost) FormattedTags() []string {
+	tags := h.AllTags()
+	if len(tags) == 0 {
+		return nil
+	}
+	inherited := make(map[string]struct{}, len(h.InheritedTags))
+	for _, t := range h.InheritedTags {
+		inherited[t] = struct{}{}
+	}
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if _, ok := inherited[t]; ok {
+			out = append(out, "%"+t)
+		} else {
+			out = append(out, "#"+t)
+		}
+	}
+	return out
+}
+
 // AllTags returns the deduplicated union of InheritedTags and Tags,
 // inherited first, then own tags. Returns nil if both are empty.
 func (h *SSHHost) AllTags() []string {

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -1705,11 +1705,12 @@ func GetAllConfigFiles() ([]string, error) {
 	return files, nil
 }
 
-// FilterVisibleHosts returns only hosts that do not have the "hidden" tag.
+// FilterVisibleHosts returns only hosts that do not have the "hidden" tag,
+// considering both own tags and tags inherited from `# FileTags:`.
 func FilterVisibleHosts(hosts []SSHHost) []SSHHost {
 	var visible []SSHHost
 	for _, h := range hosts {
-		if !hostHasTag(h.Tags, "hidden") {
+		if !hostHasTag(h.AllTags(), "hidden") {
 			visible = append(visible, h)
 		}
 	}

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -36,11 +36,37 @@ type SSHHost struct {
 	RemoteCommand string // Command to execute after SSH connection
 	RequestTTY    string // Request TTY (yes, no, force, auto)
 	Tags          []string
-	SourceFile    string // Path to the config file where this host is defined
-	LineNumber    int    // Line number in the source file where this host block starts (1-indexed)
+	InheritedTags []string // Tags inherited from `# FileTags:` in the source file. Populated by parser, never edited.
+	SourceFile    string   // Path to the config file where this host is defined
+	LineNumber    int      // Line number in the source file where this host block starts (1-indexed)
 
 	// Temporary field to handle multiple aliases during parsing
 	aliasNames []string `json:"-"` // Do not serialize this field
+}
+
+// AllTags returns the deduplicated union of InheritedTags and Tags,
+// inherited first, then own tags. Returns nil if both are empty.
+func (h *SSHHost) AllTags() []string {
+	if len(h.InheritedTags) == 0 && len(h.Tags) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(h.InheritedTags)+len(h.Tags))
+	out := make([]string, 0, len(h.InheritedTags)+len(h.Tags))
+	for _, t := range h.InheritedTags {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	for _, t := range h.Tags {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
 }
 
 // GetDefaultSSHConfigPath returns the default SSH config path for the current platform

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -250,6 +250,8 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 	var hosts []SSHHost
 	var currentHost *SSHHost
 	var pendingTags []string
+	var fileTags []string
+	var headerClosed bool
 	scanner := bufio.NewScanner(file)
 	lineNumber := 0
 
@@ -259,6 +261,33 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 
 		// Ignore empty lines
 		if line == "" {
+			continue
+		}
+
+		// File-level tags: header-only directive
+		if strings.HasPrefix(line, "# FileTags:") {
+			if headerClosed {
+				fmt.Fprintf(os.Stderr, "warning: `# FileTags:` after first Host in %s:%d ignored\n", configPath, lineNumber)
+				continue
+			}
+			tagsStr := strings.TrimSpace(strings.TrimPrefix(line, "# FileTags:"))
+			if tagsStr != "" {
+				seen := make(map[string]struct{}, len(fileTags))
+				for _, t := range fileTags {
+					seen[t] = struct{}{}
+				}
+				for _, tag := range strings.Split(tagsStr, ",") {
+					tag = strings.TrimSpace(tag)
+					if tag == "" {
+						continue
+					}
+					if _, dup := seen[tag]; dup {
+						continue
+					}
+					seen[tag] = struct{}{}
+					fileTags = append(fileTags, tag)
+				}
+			}
 			continue
 		}
 
@@ -294,6 +323,7 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 
 		switch key {
 		case "include":
+			headerClosed = true
 			// Handle Include directive
 			includeHosts, err := processIncludeDirective(value, configPath, processedFiles)
 			if err != nil {
@@ -302,6 +332,7 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 			}
 			hosts = append(hosts, includeHosts...)
 		case "host":
+			headerClosed = true
 			// New host, save previous one if it exists
 			if currentHost != nil {
 				hosts = append(hosts, *currentHost)
@@ -341,11 +372,12 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 			// For multiple hosts, we create the first one normally
 			// and will duplicate it for others after parsing the block
 			currentHost = &SSHHost{
-				Name:       validHostNames[0], // First name as reference
-				Port:       "22",              // Default port
-				Tags:       pendingTags,       // Assign pending tags to this host
-				SourceFile: absPath,           // Track which file this host comes from
-				LineNumber: lineNumber,        // Track the line number where Host declaration starts
+				Name:          validHostNames[0], // First name as reference
+				Port:          "22",              // Default port
+				Tags:          pendingTags,       // Assign pending tags to this host
+				InheritedTags: append([]string(nil), fileTags...),
+				SourceFile:    absPath,           // Track which file this host comes from
+				LineNumber:    lineNumber,        // Track the line number where Host declaration starts
 			}
 
 			// Store additional host names for later processing
@@ -913,7 +945,7 @@ func quickHostSearchInFile(hostName string, configPath string, processedFiles ma
 		line := strings.TrimSpace(scanner.Text())
 
 		// Ignore empty lines and comments (except includes)
-		if line == "" || (strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "# Tags:")) {
+		if line == "" || (strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "# Tags:") && !strings.HasPrefix(line, "# FileTags:")) {
 			continue
 		}
 

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -1824,3 +1824,141 @@ func TestAllTags_OnlyOwn(t *testing.T) {
 		t.Errorf("AllTags() = %v, want %v", got, want)
 	}
 }
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config")
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return p
+}
+
+func TestParse_FileTags_AppliedToAllHosts(t *testing.T) {
+	p := writeTempConfig(t, `# FileTags: prod, critical
+
+Host db-main
+    HostName 10.0.0.1
+
+Host web-main
+    HostName 10.0.0.2
+`)
+	hosts, err := ParseSSHConfigFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("got %d hosts, want 2", len(hosts))
+	}
+	for _, h := range hosts {
+		if !reflect.DeepEqual(h.InheritedTags, []string{"prod", "critical"}) {
+			t.Errorf("host %s InheritedTags = %v, want [prod critical]", h.Name, h.InheritedTags)
+		}
+	}
+}
+
+func TestParse_FileTags_MultipleHeaderLines_Accumulate(t *testing.T) {
+	p := writeTempConfig(t, `# FileTags: a
+# FileTags: b, c
+
+Host h1
+    HostName 10.0.0.1
+`)
+	hosts, err := ParseSSHConfigFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !reflect.DeepEqual(hosts[0].InheritedTags, []string{"a", "b", "c"}) {
+		t.Errorf("InheritedTags = %v, want [a b c]", hosts[0].InheritedTags)
+	}
+}
+
+func TestParse_FileTags_AfterFirstHost_Ignored(t *testing.T) {
+	p := writeTempConfig(t, `# FileTags: early
+
+Host h1
+    HostName 10.0.0.1
+
+# FileTags: late
+
+Host h2
+    HostName 10.0.0.2
+`)
+	hosts, err := ParseSSHConfigFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, h := range hosts {
+		if !reflect.DeepEqual(h.InheritedTags, []string{"early"}) {
+			t.Errorf("host %s InheritedTags = %v, want [early]", h.Name, h.InheritedTags)
+		}
+	}
+}
+
+func TestParse_FileTags_MixedWithOwnTags(t *testing.T) {
+	p := writeTempConfig(t, `# FileTags: prod
+
+# Tags: db
+Host h1
+    HostName 10.0.0.1
+
+Host h2
+    HostName 10.0.0.2
+`)
+	hosts, err := ParseSSHConfigFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]SSHHost{}
+	for _, h := range hosts {
+		byName[h.Name] = h
+	}
+	h1 := byName["h1"]
+	if !reflect.DeepEqual(h1.Tags, []string{"db"}) {
+		t.Errorf("h1.Tags = %v, want [db]", h1.Tags)
+	}
+	if !reflect.DeepEqual(h1.InheritedTags, []string{"prod"}) {
+		t.Errorf("h1.InheritedTags = %v, want [prod]", h1.InheritedTags)
+	}
+	if got, want := h1.AllTags(), []string{"prod", "db"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("h1.AllTags() = %v, want %v", got, want)
+	}
+	h2 := byName["h2"]
+	if len(h2.Tags) != 0 {
+		t.Errorf("h2.Tags = %v, want empty", h2.Tags)
+	}
+	if !reflect.DeepEqual(h2.InheritedTags, []string{"prod"}) {
+		t.Errorf("h2.InheritedTags = %v, want [prod]", h2.InheritedTags)
+	}
+}
+
+func TestParse_FileTags_NotCascadedViaInclude(t *testing.T) {
+	dir := t.TempDir()
+	included := filepath.Join(dir, "child")
+	if err := os.WriteFile(included, []byte(`Host child-h
+    HostName 10.0.0.3
+`), 0600); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	parent := filepath.Join(dir, "parent")
+	content := "# FileTags: parent-only\n\nInclude " + included + "\n\nHost parent-h\n    HostName 10.0.0.4\n"
+	if err := os.WriteFile(parent, []byte(content), 0600); err != nil {
+		t.Fatalf("write parent: %v", err)
+	}
+
+	hosts, err := ParseSSHConfigFile(parent)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]SSHHost{}
+	for _, h := range hosts {
+		byName[h.Name] = h
+	}
+	if got := byName["child-h"].InheritedTags; len(got) != 0 {
+		t.Errorf("child-h InheritedTags = %v, want empty (no cascade)", got)
+	}
+	if got := byName["parent-h"].InheritedTags; !reflect.DeepEqual(got, []string{"parent-only"}) {
+		t.Errorf("parent-h InheritedTags = %v, want [parent-only]", got)
+	}
+}

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -1784,5 +1785,42 @@ Host "quoted1" "quoted2"
 		if host.Hostname != "qa-test-vm.example.com" {
 			t.Errorf("Host qa-test-vm has wrong hostname: %q", host.Hostname)
 		}
+	}
+}
+
+func TestAllTags_UnionAndDedup(t *testing.T) {
+	h := SSHHost{
+		Tags:          []string{"db", "prod"},
+		InheritedTags: []string{"prod", "eu-west"},
+	}
+	got := h.AllTags()
+	want := []string{"prod", "eu-west", "db"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AllTags() = %v, want %v", got, want)
+	}
+}
+
+func TestAllTags_EmptySlicesSafe(t *testing.T) {
+	h := SSHHost{}
+	if got := h.AllTags(); len(got) != 0 {
+		t.Errorf("AllTags() on empty host = %v, want empty", got)
+	}
+}
+
+func TestAllTags_OnlyInherited(t *testing.T) {
+	h := SSHHost{InheritedTags: []string{"a", "b"}}
+	got := h.AllTags()
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AllTags() = %v, want %v", got, want)
+	}
+}
+
+func TestAllTags_OnlyOwn(t *testing.T) {
+	h := SSHHost{Tags: []string{"a", "b"}}
+	got := h.AllTags()
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AllTags() = %v, want %v", got, want)
 	}
 }

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -1788,6 +1788,23 @@ Host "quoted1" "quoted2"
 	}
 }
 
+func TestFilterVisibleHosts_HonorsInheritedHiddenTag(t *testing.T) {
+	hosts := []SSHHost{
+		{Name: "visible"},
+		{Name: "own-hidden", Tags: []string{"hidden"}},
+		{Name: "file-hidden", InheritedTags: []string{"hidden"}},
+		{Name: "file-hidden-mixed", Tags: []string{"db"}, InheritedTags: []string{"hidden"}},
+	}
+	got := FilterVisibleHosts(hosts)
+	if len(got) != 1 || got[0].Name != "visible" {
+		names := make([]string, len(got))
+		for i, h := range got {
+			names[i] = h.Name
+		}
+		t.Errorf("FilterVisibleHosts = %v, want [visible]", names)
+	}
+}
+
 func TestAllTags_UnionAndDedup(t *testing.T) {
 	h := SSHHost{
 		Tags:          []string{"db", "prod"},

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -1962,3 +1962,82 @@ func TestParse_FileTags_NotCascadedViaInclude(t *testing.T) {
 		t.Errorf("parent-h InheritedTags = %v, want [parent-only]", got)
 	}
 }
+
+func TestRoundTrip_FileTagsPreserved_OnAddEditDelete(t *testing.T) {
+	initial := `# FileTags: prod, eu
+
+# Tags: db
+Host h1
+    HostName 10.0.0.1
+    User admin
+
+Host h2
+    HostName 10.0.0.2
+    User admin
+`
+	p := writeTempConfig(t, initial)
+
+	// Edit h1
+	newH1 := SSHHost{Name: "h1", Hostname: "10.0.0.99", User: "admin", Port: "22", Tags: []string{"db"}}
+	if err := UpdateSSHHostInFile("h1", newH1, p); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	assertFileTagsHeader(t, p, "# FileTags: prod, eu")
+	assertNoFileTagsBleedIntoHostTags(t, p)
+
+	// Add h3
+	h3 := SSHHost{Name: "h3", Hostname: "10.0.0.3", User: "admin", Port: "22"}
+	if err := AddSSHHostToFile(h3, p); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	assertFileTagsHeader(t, p, "# FileTags: prod, eu")
+
+	// Delete h2
+	if err := DeleteSSHHostFromFile("h2", p); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	assertFileTagsHeader(t, p, "# FileTags: prod, eu")
+
+	// Reparse — InheritedTags must remain set on all hosts; none of them should have prod/eu in their own Tags slice.
+	hosts, err := ParseSSHConfigFile(p)
+	if err != nil {
+		t.Fatalf("parse after round-trip: %v", err)
+	}
+	for _, h := range hosts {
+		if !reflect.DeepEqual(h.InheritedTags, []string{"prod", "eu"}) {
+			t.Errorf("host %s InheritedTags = %v, want [prod eu]", h.Name, h.InheritedTags)
+		}
+		for _, tag := range h.Tags {
+			if tag == "prod" || tag == "eu" {
+				t.Errorf("host %s has inherited tag %q duplicated in own Tags", h.Name, tag)
+			}
+		}
+	}
+}
+
+func assertFileTagsHeader(t *testing.T, path, wantLine string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(b), wantLine+"\n") {
+		t.Errorf("expected %q in file, got:\n%s", wantLine, string(b))
+	}
+}
+
+func assertNoFileTagsBleedIntoHostTags(t *testing.T, path string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "# Tags:") {
+			if strings.Contains(trim, "prod") || strings.Contains(trim, "eu") {
+				t.Errorf("inherited tag bled into per-host # Tags: line: %q", trim)
+			}
+		}
+	}
+}

--- a/internal/ui/edit_form.go
+++ b/internal/ui/edit_form.go
@@ -596,6 +596,20 @@ func (m *editFormModel) renderEditGeneralTab() string {
 		if m.focusArea == focusAreaProperties && m.focused == field.index {
 			fieldStyle = m.styles.FocusedLabel
 		}
+		if field.index == 7 && len(m.host.InheritedTags) > 0 {
+			tagLabels := make([]string, 0, len(m.host.InheritedTags))
+			for _, t := range m.host.InheritedTags {
+				tagLabels = append(tagLabels, "#"+t)
+			}
+			src := formatConfigFile(m.host.SourceFile)
+			if src == "" {
+				src = "file"
+			}
+			line := fmt.Sprintf("Inherited tags: %s (from %s, not editable here)",
+				strings.Join(tagLabels, " "), src)
+			b.WriteString(m.styles.FormHelp.Render(line))
+			b.WriteString("\n\n")
+		}
 		b.WriteString(fieldStyle.Render(field.label))
 		b.WriteString("\n")
 		b.WriteString(m.inputs[field.index].View())

--- a/internal/ui/edit_form.go
+++ b/internal/ui/edit_form.go
@@ -599,7 +599,7 @@ func (m *editFormModel) renderEditGeneralTab() string {
 		if field.index == 7 && len(m.host.InheritedTags) > 0 {
 			tagLabels := make([]string, 0, len(m.host.InheritedTags))
 			for _, t := range m.host.InheritedTags {
-				tagLabels = append(tagLabels, "#"+t)
+				tagLabels = append(tagLabels, "%"+t)
 			}
 			src := formatConfigFile(m.host.SourceFile)
 			if src == "" {

--- a/internal/ui/info_form.go
+++ b/internal/ui/info_form.go
@@ -102,6 +102,13 @@ func (m *infoFormModel) View() string {
 		{"Tags", formatTags(m.host.Tags)},
 	}
 
+	if len(m.host.InheritedTags) > 0 {
+		sections = append(sections, struct {
+			label string
+			value string
+		}{"Inherited", formatTags(m.host.InheritedTags)})
+	}
+
 	// Render each section
 	for _, section := range sections {
 		// Label style

--- a/internal/ui/sort.go
+++ b/internal/ui/sort.go
@@ -93,7 +93,7 @@ func (m Model) filterHostsByWord(word string) []config.SSHHost {
 			}
 
 			// Check the tags
-			for _, tag := range host.Tags {
+			for _, tag := range host.AllTags() {
 				if strings.Contains(strings.ToLower(tag), word) {
 					filtered = append(filtered, host)
 					break

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -36,9 +36,9 @@ func (m *Model) calculateDynamicColumnWidths(hosts []config.SSHHost) (int, int, 
 
 		// Calculate tags string length
 		var tagsStr string
-		if len(host.Tags) > 0 {
+		if len(host.AllTags()) > 0 {
 			var formattedTags []string
-			for _, tag := range host.Tags {
+			for _, tag := range host.AllTags() {
 				formattedTags = append(formattedTags, "#"+tag)
 			}
 			tagsStr = strings.Join(formattedTags, " ")
@@ -135,10 +135,10 @@ func (m *Model) updateTableRows() {
 
 		// Format tags for display
 		var tagsStr string
-		if len(host.Tags) > 0 {
+		if len(host.AllTags()) > 0 {
 			// Add the # prefix to each tag and join them with spaces
 			var formattedTags []string
-			for _, tag := range host.Tags {
+			for _, tag := range host.AllTags() {
 				formattedTags = append(formattedTags, "#"+tag)
 			}
 			tagsStr = strings.Join(formattedTags, " ")
@@ -294,10 +294,10 @@ func calculateTagsColumnWidth(hosts []config.SSHHost) int {
 	for _, host := range hosts {
 		// Format tags exactly as they appear in the table
 		var tagsStr string
-		if len(host.Tags) > 0 {
+		if len(host.AllTags()) > 0 {
 			// Add the # prefix to each tag and join them with spaces
 			var formattedTags []string
-			for _, tag := range host.Tags {
+			for _, tag := range host.AllTags() {
 				formattedTags = append(formattedTags, "#"+tag)
 			}
 			tagsStr = strings.Join(formattedTags, " ")

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -36,11 +36,7 @@ func (m *Model) calculateDynamicColumnWidths(hosts []config.SSHHost) (int, int, 
 
 		// Calculate tags string length
 		var tagsStr string
-		if len(host.AllTags()) > 0 {
-			var formattedTags []string
-			for _, tag := range host.AllTags() {
-				formattedTags = append(formattedTags, "#"+tag)
-			}
+		if formattedTags := host.FormattedTags(); len(formattedTags) > 0 {
 			tagsStr = strings.Join(formattedTags, " ")
 		}
 		if len(tagsStr) > maxTagsLength {
@@ -135,12 +131,7 @@ func (m *Model) updateTableRows() {
 
 		// Format tags for display
 		var tagsStr string
-		if len(host.AllTags()) > 0 {
-			// Add the # prefix to each tag and join them with spaces
-			var formattedTags []string
-			for _, tag := range host.AllTags() {
-				formattedTags = append(formattedTags, "#"+tag)
-			}
+		if formattedTags := host.FormattedTags(); len(formattedTags) > 0 {
 			tagsStr = strings.Join(formattedTags, " ")
 		}
 
@@ -294,12 +285,7 @@ func calculateTagsColumnWidth(hosts []config.SSHHost) int {
 	for _, host := range hosts {
 		// Format tags exactly as they appear in the table
 		var tagsStr string
-		if len(host.AllTags()) > 0 {
-			// Add the # prefix to each tag and join them with spaces
-			var formattedTags []string
-			for _, tag := range host.AllTags() {
-				formattedTags = append(formattedTags, "#"+tag)
-			}
+		if formattedTags := host.FormattedTags(); len(formattedTags) > 0 {
 			tagsStr = strings.Join(formattedTags, " ")
 		}
 

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -100,10 +100,10 @@ func NewModel(hosts []config.SSHHost, configFile string, searchMode bool, curren
 
 		// Format tags for display
 		var tagsStr string
-		if len(host.Tags) > 0 {
+		if allTags := host.AllTags(); len(allTags) > 0 {
 			// Add the # prefix to each tag and join them with spaces
 			var formattedTags []string
-			for _, tag := range host.Tags {
+			for _, tag := range allTags {
 				formattedTags = append(formattedTags, "#"+tag)
 			}
 			tagsStr = strings.Join(formattedTags, " ")

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -100,12 +100,7 @@ func NewModel(hosts []config.SSHHost, configFile string, searchMode bool, curren
 
 		// Format tags for display
 		var tagsStr string
-		if allTags := host.AllTags(); len(allTags) > 0 {
-			// Add the # prefix to each tag and join them with spaces
-			var formattedTags []string
-			for _, tag := range allTags {
-				formattedTags = append(formattedTags, "#"+tag)
-			}
+		if formattedTags := host.FormattedTags(); len(formattedTags) > 0 {
 			tagsStr = strings.Join(formattedTags, " ")
 		}
 


### PR DESCRIPTION
feat: add `# FileTags:` directive for file-wide inherited tags

---

## Summary

Adds support for a `# FileTags:` header directive that lets every host in a config file inherit a shared set of tags, without having to repeat them on each host. Inherited tags are read-only, displayed alongside owned tags with a distinct `%` prefix, and fully composable with existing search, filter, and `hidden` semantics.

## Motivation

When organizing hosts across multiple config files (typically via `Include` directives), users often want every entry in a file to share a common label `work`, `lab`, `client-x`, or `hidden` without duplicating it on each host. Today that requires editing every host or relying on filename conventions. A single header directive at the top of the file is cleaner and survives host add/edit/delete operations performed by the TUI.

## What changes

- **Parser**: `# FileTags: foo, bar` (case-insensitive, must appear before the first `Host` entry) is parsed once per file and propagated to each host's new `InheritedTags` field. Directives after the first `Host` are ignored with a warning. Round-trip safe, the header is preserved across `sshm` edits.
- **Model**: new `SSHHost.InheritedTags` field and `AllTags()` / `FormattedTags()` helpers. `AllTags()` returns the deduplicated union (inherited first). `FormattedTags()` prefixes inherited tags with `%` and owned tags with `#`.
- **Display**: TUI table, `sshm info`, and `sshm` CLI listing all show owned + inherited tags. Edit form surfaces inherited tags read-only above the editable `Tags` field, with a hint pointing to the source file.
- **Search & filter**: existing tag matchers (`filterHosts`, `filterHostsByWord`) operate on `AllTags()`, so inherited tags are searchable identically to owned ones.
- **Hidden semantics**: a file-wide `# FileTags: hidden` hides every host in that file from the default TUI view, just like the per-host `hidden` tag.
- **Docs**: README documents the directive and the `%` / `#` prefix convention.

## Usage

```sshconfig
# FileTags: work, lab

Host db-prod
    HostName db.example.com
    User admin

Host db-staging
    HostName staging-db.example.com
    User admin
```

Both hosts inherit `work` and `lab`. They display as `%work %lab` in the table; if you add a per-host `Tags backup`, the row shows `%work %lab #backup`.

## Test plan

- [x] `internal/config/ssh_test.go` covers parsing, round-trip preservation across host add/edit/delete, and the "directive after first Host is ignored" case.
- [x] `cmd/search_test.go` covers searching across inherited tags through `filterHosts`.
- [x] `go test ./internal/...` passes (pre-existing Windows-specific failures on `TestGetDefaultSSHConfigPath` exist on `main` and are unrelated).
- [x] Manual TUI check: edit form shows inherited tags read-only, info view shows the `Inherited` row, `hidden` directive hides the whole file.
