### PR TITLE
fix: strip surrounding quotes from parsed IdentityFile (issue #16)

### DIFF
--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -343,7 +343,8 @@ func parseSSHConfigFileWithProcessedFiles(configPath string, processedFiles map[
 			}
 		case "identityfile":
 			if currentHost != nil {
-				currentHost.Identity = value
+				// Remove surrounding double quotes if present
+				currentHost.Identity = strings.Trim(value, `"`)
 			}
 		case "proxyjump":
 			if currentHost != nil {

--- a/internal/config/ssh_test.go
+++ b/internal/config/ssh_test.go
@@ -1555,6 +1555,38 @@ func TestAddSSHHostWithSpacesInPath(t *testing.T) {
 	}
 }
 
+func TestParseSSHConfigWithQuotedIdentityFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configFile := filepath.Join(tempDir, "config")
+	configContent := `Host with-quoted-key
+    HostName example.com
+    User user
+    IdentityFile "/path/with spaces/id key"
+`
+
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create config: %v", err)
+	}
+
+	hosts, err := ParseSSHConfigFile(configFile)
+	if err != nil {
+		t.Fatalf("ParseSSHConfigFile() error = %v", err)
+	}
+
+	if len(hosts) != 1 {
+		t.Fatalf("Expected 1 host, got %d", len(hosts))
+	}
+
+	if strings.Contains(hosts[0].Identity, `"`) {
+		t.Errorf("Identity %q still contains quotes", hosts[0].Identity)
+	}
+	if got, want := hosts[0].Identity, "/path/with spaces/id key"; got != want {
+		t.Errorf("Identity = %q, want %q", got, want)
+	}
+}
+
 func TestIsNonSSHConfigFile(t *testing.T) {
 	tests := []struct {
 		fileName string


### PR DESCRIPTION
Hi @Gu1llaum-3,

First, thank you for sshm — I've been using it daily for a long time and
it's genuinely a great tool. I only noticed this issue recently after
moving one of my key files to a path containing spaces — that's the
condition under which the write side wraps the value in quotes, which the
parser doesn't undo on read.

## The bug

When a host's `IdentityFile` points to a path containing spaces, opening
the edit form and pressing Save without modification fails with:

    Error: identity file does not exist: "/path/with spaces/key"

Note the literal `"` characters wrapping the path in the error message —
they are part of the value the validator is checking, not just message
formatting.

## Why

In d686d97 (`Quote IdentityFile paths containing spaces to prevent SSH config
errors`) the write side was fixed: `formatSSHConfigValue` wraps the path in
quotes when it contains spaces. The matching read side was never added, so
the parser keeps the literal `"` chars as part of `host.Identity`. The edit
form then pre-populates its input with the quoted string, and
`ValidateIdentityFile` calls `os.Stat` on `"/path/..."` (with the quote
characters as part of the path), which fails.

This is essentially the second half of the bug originally reported in #16 —
that exact error message appears in the original report, but only the
write-side regression was addressed when the issue was closed.

## The fix

Mirror the existing Host-name quote-stripping at lines 302 and 927: strip
surrounding double quotes on the parser side, only in the `identityfile`
case. `formatSSHConfigValue` on the write side is only applied to
`IdentityFile`, so no other field needs the same treatment.

```go
case "identityfile":
    if currentHost != nil {
        // Remove surrounding double quotes if present
        currentHost.Identity = strings.Trim(value, `"`)
    }
```

The new test follows the style of `TestParseSSHConfigWithQuotedHostNames`
from 87f8fb9.

## Verified locally

- `go test ./...` passes
- Built and confirmed that opening the edit form on a host with a quoted
  `IdentityFile` now shows the bare path, and Save succeeds. The write side
  re-quotes correctly, so the on-disk config keeps its quotes.

Thanks again for maintaining sshm, and happy to revise if you'd like
anything different.

Refs: #16
