### PR TITLE
feat: add support for rootless installation

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -11,6 +11,7 @@ curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh
 ```
 
 ### Quick Install (User Only)
+
 This option will install SSHM locally for the installation user only, this removes the need for sudo / root permissions. SSHM will be installed at `~/.local/bin` by default.
 
 ```bash
@@ -30,11 +31,13 @@ irm https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/windows.ps1 |
 ### Install Options
 
 **Force install without prompts:**
+
 ```powershell
 iex "& { $(irm https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/windows.ps1) } -Force"
 ```
 
 **Custom installation directory:**
+
 ```powershell
 iex "& { $(irm https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/windows.ps1) } -InstallDir 'C:\tools'"
 ```
@@ -42,11 +45,13 @@ iex "& { $(irm https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/wi
 ## Unix/Linux/macOS Advanced Options
 
 **Force install without prompts:**
+
 ```bash
 FORCE_INSTALL=true bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh)"
 ```
 
 **Disable auto-install when using pipe:**
+
 ```bash
 FORCE_INSTALL=false bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh)"
 ```
@@ -54,16 +59,19 @@ FORCE_INSTALL=false bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1ll
 ### Manual Install
 
 1. Download the script:
+
 ```bash
 curl -O https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh
 ```
 
 2. Make it executable:
+
 ```bash
 chmod +x unix.sh
 ```
 
 3. Run the installer:
+
 ```bash
 ./unix.sh
 ```

--- a/install/README.md
+++ b/install/README.md
@@ -10,6 +10,13 @@ This directory contains installation scripts for SSHM.
 curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh | bash
 ```
 
+### Quick Install (User Only)
+This option will install SSHM locally for the installation user only, this removes the need for sudo / root permissions. SSHM will be installed at `~/.local/bin` by default.
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh | LOCAL_INSTALL=true bash
+```
+
 **Note:** When using the pipe method, the installer will automatically proceed with installation if SSHM is already installed.
 
 ## Windows Installation

--- a/install/README.md
+++ b/install/README.md
@@ -56,6 +56,12 @@ FORCE_INSTALL=true bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1lla
 FORCE_INSTALL=false bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh)"
 ```
 
+**Install locally without root permissions:**
+
+```bash
+LOCAL_INSTALL=true bash -c "$(curl -sSL https://raw.githubusercontent.com/Gu1llaum-3/sshm/main/install/unix.sh)"
+```
+
 ### Manual Install
 
 1. Download the script:

--- a/install/unix.sh
+++ b/install/unix.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-INSTALL_DIR="/usr/local/bin"
-EXECUTABLE_NAME=sshm
-EXECUTABLE_PATH="$INSTALL_DIR/$EXECUTABLE_NAME"
+# Default configurations, overrideable via environment variables
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+EXECUTABLE_NAME="sshm"
 USE_SUDO="false"
 OS=""
 ARCH=""
 FORCE_INSTALL="${FORCE_INSTALL:-false}"
 SSHM_VERSION="${SSHM_VERSION:-latest}"
+LOCAL_INSTALL="${LOCAL_INSTALL:-false}"
+
+# The full path will be evaluated in main() after parsing arguments
+EXECUTABLE_PATH=""
 
 RED='\033[0;31m'
 PURPLE='\033[0;35m'
@@ -19,6 +23,7 @@ usage() {
     printf "${PURPLE}SSHM Installation Script${NC}\n\n"
     printf "Usage:\n"
     printf "  Default (latest stable):     ${GREEN}bash install.sh${NC}\n"
+    printf "  Local install (~/sour/bin):${GREEN}bash install.sh --local${NC}\n"
     printf "  Specific version:            ${GREEN}SSHM_VERSION=v1.8.0 bash install.sh${NC}\n"
     printf "  Beta/pre-release:            ${GREEN}SSHM_VERSION=v1.8.1-beta bash install.sh${NC}\n"
     printf "  Force install:               ${GREEN}FORCE_INSTALL=true bash install.sh${NC}\n"
@@ -26,7 +31,8 @@ usage() {
     printf "Environment variables:\n"
     printf "  SSHM_VERSION    - Version to install (default: latest)\n"
     printf "  FORCE_INSTALL   - Skip confirmation prompts (default: false)\n"
-    printf "  INSTALL_DIR     - Installation directory (default: /usr/local/bin)\n\n"
+    printf "  INSTALL_DIR     - Installation directory (default: /usr/local/bin)\n"
+    printf "  LOCAL_INSTALL   - Install to ~/.local/bin without sudo (default: false)\n\n"
 }
 
 setSystem() {
@@ -40,14 +46,18 @@ setSystem() {
         arm64) ARCH="arm64" ;;
     esac
 
-    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+    OS=$(echo $(uname) | tr '[:upper:]' '[:lower:]')
     
     # Determine if we need sudo
-    if [ "$OS" = "linux" ]; then
-        USE_SUDO="true"
-    fi
-    if [ "$OS" = "darwin" ]; then
-        USE_SUDO="true"
+    if [ "$LOCAL_INSTALL" = "true" ]; then
+        USE_SUDO="false"
+    else
+        # Automatically check if we lack write permissions to the install directory
+        if [ ! -w "$INSTALL_DIR" ]; then
+            if [ "$OS" = "linux" ] || [ "$OS" = "darwin" ]; then
+                USE_SUDO="true"
+            fi
+        fi
     fi
 }
 
@@ -204,11 +214,27 @@ checkExisting() {
 }
 
 main() {
-    # Check for help argument
-    if [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "help" ]; then
-        usage
-        exit 0
+    # Parse arguments
+    for arg in "$@"; do
+        case $arg in
+            -h|--help|help)
+                usage
+                exit 0
+                ;;
+            -l|--local)
+                LOCAL_INSTALL="true"
+                ;;
+        esac
+    done
+    
+    # Handle local install routing
+    if [ "$LOCAL_INSTALL" = "true" ]; then
+        INSTALL_DIR="$HOME/.local/bin"
+        mkdir -p "$INSTALL_DIR"
     fi
+    
+    # Set the final executable path
+    EXECUTABLE_PATH="$INSTALL_DIR/$EXECUTABLE_NAME"
     
     printf "${PURPLE}Installing SSHM - SSH Connection Manager${NC}\n\n"
     


### PR DESCRIPTION
This PR introduces the ability for users to install sshm locally without requiring root privileges, addresses issue #55 . It also improves the overall installation experience by automatically bypassing sudo prompts if the user already has write permissions to the target installation directory.

**Key Changes:**
- Introduced LOCAL_INSTALL Environment Variable: Users can now set LOCAL_INSTALL=true to automatically default the INSTALL_DIR to $HOME/.local/bin and bypass sudo.
- Permissions Detection: Updated the setSystem function to evaluate write permissions. If the user has write access to the specified INSTALL_DIR (or its parent directory if it doesn't exist yet), the script will automatically set USE_SUDO="false".
- Dynamic Directory Creation: Added a step in the install function to run mkdir -p "$INSTALL_DIR" to ensure the target directory exists before attempting to move the binary. This is especially useful for fresh systems where ~/.local/bin might not be created yet.
- Updated Usage Menu: Added the new LOCAL_INSTALL option to the help/usage output for better discoverability.

**Usage Examples:**

Install locally to user's home directory:

``` shell
LOCAL_INSTALL=true bash install.sh
```
Install to a custom directory owned by the user (will auto-detect permissions and skip sudo):

``` shell 
INSTALL_DIR=$HOME/my-bin-folder bash install.sh
```

